### PR TITLE
Implement concurrency + recovery redesign; OCR all corpus PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,106 @@
+# paperscale
+
+OCR documents to Markdown at scale using vision language models (VLMs) served
+over an OpenAI-compatible API. paperscale renders each PDF page to an image,
+sends it to the model, validates the Markdown, and assembles the pages into one
+document. Every page attempt is journaled to a local ledger, so a crashed or
+interrupted run resumes exactly where it stopped without re-OCRing finished
+pages.
+
+## Install
+
+paperscale is a Poetry project. Install the package and its console scripts:
+
+```bash
+poetry install
+```
+
+This installs two commands into the environment: `paperscale` (the OCR runner)
+and `paperscale-mock-api` (a deterministic mock inference server for local
+development and tests). Run them with `poetry run paperscale ...` or activate the
+environment first.
+
+For the mock server you also need the optional extra:
+
+```bash
+poetry install -E mock-api      # or: pip install 'paperscale[mock-api]'
+```
+
+## Quickstart (against the mock server)
+
+Start the deterministic mock inference API in one terminal:
+
+```bash
+poetry run paperscale-mock-api serve --port 8009 --model mock-vlm
+```
+
+OCR a PDF in another terminal:
+
+```bash
+poetry run paperscale run \
+  --input document.pdf \
+  --output document.md \
+  --base-url http://127.0.0.1:8009 \
+  --model mock-vlm \
+  --job-id mydoc
+```
+
+`run` prints a one-line summary and exits `0` when every page succeeds. If the
+run stops early — a page fails, the provider trips the circuit breaker, or the
+process is killed — resume it:
+
+```bash
+poetry run paperscale resume mydoc          # reuses the original job's settings
+poetry run paperscale status mydoc          # succeeded/pending/failed/ambiguous counts
+```
+
+## Running against a real vLLM server
+
+The runner speaks the OpenAI chat-completions protocol, so any OpenAI-compatible
+server works. Point `--base-url` at the server (paperscale appends `/v1` when you
+omit it) and pass the served model id. Validate reachability and model
+availability before starting a run:
+
+```bash
+poetry run paperscale doctor provider \
+  --base-url http://127.0.0.1:8000 \
+  --model your-served-model \
+  --capacity local-vllm-small
+```
+
+`doctor` exits `0` when the server is reachable and serves the requested model,
+`1` otherwise. Then run as above with the real `--base-url` and `--model`.
+
+The mock server is the deterministic baseline for plumbing, ledger, retry, and
+assembly behavior; a real vLLM/SmolVLM server is for model compatibility and OCR
+quality. See [docs/mock-api.md](docs/mock-api.md) for the differences.
+
+## Capacity and profiles
+
+`--capacity` selects a provider pressure profile that drives concurrency limits,
+retry backoff, and the circuit breaker:
+
+| Capacity | In-flight | Circuit threshold | Use |
+| --- | --- | --- | --- |
+| `local-vllm-small` (default) | 2 | 3 | a single local GPU |
+| `local-vllm-large` | 8 | 5 | a larger local deployment |
+| `remote-openai-compatible` | 4 | 4 | a hosted endpoint |
+
+`--profile` selects the OCR prompt/parser. The default `generic_vlm_markdown`
+(default model `generic-vlm-markdown`) suits most VLMs; `strict_json_ocr`,
+`glm_ocr`, `lighton_ocr_2_1b`, and `deepseek_ocr_2` target specific models.
+
+## Documentation
+
+- [docs/cli.md](docs/cli.md) — every command, flag, example, and exit code.
+- [docs/state-layout.md](docs/state-layout.md) — the on-disk `.paperscale/jobs/<job_id>` layout.
+- [docs/mock-api.md](docs/mock-api.md) — the mock inference server.
+- [docs/ledger-recovery.md](docs/ledger-recovery.md) — ledger safety, recovery, and capacity behavior.
+
+## Development
+
+```bash
+poetry run pytest        # run the test suite (stdlib unittest, run via pytest)
+poetry run ruff check .  # lint
+poetry run pyrefly check src/paperscale  # type-check
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,134 @@
+# paperscale CLI reference
+
+All commands run as `paperscale <command>` (use `poetry run paperscale ...` in a
+Poetry checkout). State lives under `--state-root` (default `.paperscale`); see
+[state-layout.md](state-layout.md).
+
+## Common options
+
+| Option | Commands | Meaning |
+| --- | --- | --- |
+| `--state-root PATH` | all stateful commands | state directory (default `.paperscale`) |
+| `--base-url URL` | `run`, `doctor` | OpenAI-compatible base URL; `/v1` is appended when omitted |
+| `--model ID` | `run`, `doctor` | served model id (`run` defaults to the profile's model) |
+| `--profile NAME` | `run`, `doctor` | OCR profile (default `generic_vlm_markdown`) |
+| `--capacity NAME` | `run`, `doctor` | capacity profile (default `local-vllm-small`) |
+
+## `run` — OCR a document
+
+Renders each page, OCRs it through the provider, and assembles the Markdown.
+
+```bash
+paperscale run --input doc.pdf --output doc.md --base-url http://127.0.0.1:8009 --model mock-vlm --job-id doc1
+```
+
+| Option | Required | Meaning |
+| --- | --- | --- |
+| `--input PATH` | yes | PDF input |
+| `--output PATH` | yes | Markdown output |
+| `--base-url URL` | yes | provider base URL |
+| `--job-id ID` | no | workload id (generated from the filename when omitted) |
+| `--model`, `--profile`, `--capacity`, `--state-root` | no | see common options |
+| `--allow-partial` | no | assemble succeeded pages even if some pages fail |
+
+The runner processes pages sequentially under managed resource ordering and a
+capacity-driven retry/circuit-breaker. A transient provider error is retried with
+exponential backoff; after the capacity's failure threshold the circuit opens,
+the run stops, and unfinished pages stay `pending` for `resume`.
+
+**Exit code:** `0` when every page succeeds (or `--allow-partial` and at least
+one page succeeds), `1` otherwise.
+
+## `resume` — continue a stopped job
+
+```bash
+paperscale resume doc1
+paperscale resume doc1 --retry-ambiguous --allow-partial
+```
+
+Reuses the original job's input, provider URL, model, and capacity from its
+manifest, so no `--base-url` is needed. Recovers leases whose worker died, then
+processes the remaining pages.
+
+| Option | Meaning |
+| --- | --- |
+| `--retry-ambiguous` | retry `ambiguous` in-flight attempts (risks duplicate provider calls) |
+| `--allow-partial` | assemble succeeded pages even if some fail |
+| `--state-root` | see common options |
+
+**Exit code:** same rule as `run`.
+
+## `status` — show progress
+
+```bash
+paperscale status doc1
+paperscale status doc1 --json
+```
+
+Reads the compact status index only (no artifact tree scan) and prints
+succeeded / pending / failed / ambiguous counts. `--json` emits a machine-readable
+summary. **Exit code:** `0`.
+
+## `reconcile` — resolve ambiguous pages
+
+An `ambiguous` page is one whose provider call was in flight when its lease
+expired: the call may or may not have completed, so paperscale never retries it
+silently. List them, or resolve one:
+
+```bash
+paperscale reconcile doc1                 # list ambiguous attempts + guidance
+paperscale reconcile doc1 --json
+paperscale reconcile doc1 --supersede 4   # discard the attempt, requeue page 4 as pending
+paperscale reconcile doc1 --accept 4      # accept page 4's existing artifact as succeeded
+```
+
+`--supersede` and `--accept` are mutually exclusive. Both mark the prior attempt
+`superseded` in the ledger; `--accept` additionally adopts the page's
+already-written artifact and re-assembles the document if it is now complete.
+**Exit code:** `0`.
+
+## `fsck` — consistency check (read-only)
+
+```bash
+paperscale fsck doc1
+```
+
+Cross-checks the ledger, indexes, and artifacts without writing anything. Emits a
+JSON report with an `issues` list. Issue codes: `missing_artifact`,
+`orphan_artifact`, `missing_page`, `count_mismatch`, `ledger_mismatch`,
+`fingerprint_mismatch`, `stale_lease`. **Exit code:** `0` when clean, `1` when any
+issue is found.
+
+## `repair-index` — rebuild compact indexes
+
+```bash
+paperscale repair-index doc1
+```
+
+Rebuilds the status/resume/reconcile indexes from the artifacts actually present
+on disk (a page is `succeeded` only if its artifact exists). Use after manual
+recovery or if an index is lost. **Exit code:** `0`.
+
+## `doctor provider` — validate a provider
+
+```bash
+paperscale doctor provider --base-url http://127.0.0.1:8000 --model your-model
+```
+
+Checks that the server is reachable and lists the requested model in `/v1/models`,
+and reports the resolved OCR and capacity profiles. Starts no OCR work.
+**Exit code:** `0` when compatible, `1` otherwise.
+
+## `assemble` — combine pre-OCR'd pages
+
+Assembles a JSONL file of completed page artifacts into one document, independent
+of the runner.
+
+```bash
+paperscale assemble --input pages.jsonl --output doc.md --title "My Document" --enforce-quality
+```
+
+Each JSONL line needs `document_id`, `page_number`, and `markdown`.
+`--enforce-quality` rejects empty, mojibake, or repeated fragments;
+`--allow-partial` marks the output partial; `--title` prepends an H1.
+**Exit code:** `0`.

--- a/docs/concurrency-and-queuing.md
+++ b/docs/concurrency-and-queuing.md
@@ -1,0 +1,225 @@
+# Concurrency and Queuing Design
+
+Status: **implemented**. Describes the multi-worker request pipeline that replaced
+the strictly-sequential `DocumentOcrRunner` loop. Builds on the durability model in
+`recovery-retry-redesign.md` and `ledger-recovery.md`. Implementation:
+`runner.py` (`_run_pool`, `_worker`, `_attempt_page`, `_IndexWriter`),
+`async_pool.py:AdaptiveLimiter`, `providers/async_openai_chat.py`,
+`providers/self_hosted.py:ProviderOverloadController` (AIMD), and
+`state/claim_store.py` (O_EXCL claim tier). The single-machine multi-process tier is
+driven by `paperscale enqueue` + `paperscale work`. Tests:
+`tests/test_concurrency_pool.py`, `tests/providers/test_aimd.py`,
+`tests/state/test_claim_store.py`.
+
+Operational note (server-side hardening): on a 24 GB GPU, DeepSeek-OCR-2 OOMs the
+engine ("death, not degradation") under the doc's defaults — launch vLLM with
+`--gpu-memory-utilization ≈ 0.70` and a right-sized `--max-num-seqs`/
+`--max-num-batched-tokens` to leave headroom for vision-tower activations. The
+client layers (AIMD, circuit breaker) protect against over-send but cannot revive a
+dead engine.
+
+## Goal
+
+Keep a local vLLM server's continuous-batching engine saturated — always offer
+the server more work than it can run at once — without exhausting file
+descriptors, sockets, or memory, and without weakening the per-page durability
+contract.
+
+## Baseline reality
+
+The live runner is **strictly sequential**: `_process_pages` loops pages one at a
+time and `_process_page` calls `provider.send()` synchronously. The
+`ResourceGovernor` (`resources.py`), `Scheduler`/`LazyPageQueue` (`scheduler.py`),
+and `ProviderOverloadController` (`providers/self_hosted.py`) are **unattached
+scaffolding** — exercised by unit tests but never instantiated on the live
+`run`/`resume` path. The capacity-profile limits are inert except in `doctor`.
+
+## Concurrency model (olmOCR-shaped)
+
+- **Single-process `asyncio` pool of full-lifecycle workers.** Each worker owns a
+  page end to end: render → submit → await response → post-process → retry or
+  finalize. There is **no** submit-thread / poll-thread split — that gives only
+  one in-flight request and contends on a shared mutable queue. Full-lifecycle
+  workers get automatic backpressure: a worker doesn't pull its next page until
+  its current one resolves.
+- **`asyncio`, not OS threads.** The work is I/O-bound (HTTP + fsync); an event
+  loop holds many in-flight requests cheaply. `/v1/chat/completions` is
+  synchronous request/response — workers `await` their own responses; there is no
+  server to "poll".
+- **Saturation is governed by outstanding-request count**, not local queue depth.
+  vLLM does continuous batching server-side; our job is to keep enough requests
+  outstanding. Surplus beyond `max_num_seqs` sits in vLLM's waiting queue (adds
+  latency, not throughput).
+- **Durability edge retained.** Per-page ledger + artifacts + adopt-then-requeue
+  (see `recovery-retry-redesign.md`) is *finer* than olmOCR's work-item
+  completion markers. Keep it. True multi-*node* execution is deferred to a coarse
+  work-item claim tier later, mapping onto the existing
+  `worker_id`/`epoch`/`lease_expires_at`/`heartbeat_at` ledger fields.
+
+## Backpressure knobs (three, not one)
+
+"Too many pages" decomposes into three independent limits. One overloaded knob
+cannot express them: sized for the GPU it under-bounds memory; sized for memory it
+starves the GPU.
+
+1. **`max_in_flight_requests`** — process-wide `asyncio.Semaphore`, acquired
+   *before* a request leaves for the server, released on response. This is the
+   global "pages sent to the server" cap. **Default `4 × server max_num_seqs`,
+   configurable.** Client concurrency governs vLLM's *waiting queue depth*, not
+   its active batch — surplus beyond `max_num_seqs` queues cheaply in **host RAM**
+   (raw image bytes), keeping the scheduler from starving between steps. The
+   HTTP connection pool MUST be sized to match this number. The limit is **global
+   across all document workers**, not per-document (per-document would let K
+   documents open K×limit sockets and reopen the FD problem). The 4× default
+   **assumes a dedicated server** (only vLLM running) with a correctly-sized
+   `max_num_seqs` and `gpu_memory_utilization ≈ 0.85`; on a shared GPU or
+   undersized headroom, lower it. See "Protecting the server" below.
+2. **`max_open_documents`** — bounds concurrently open PDF handles under **lazy**
+   rendering (one decoded page at a time per active document). An open PDF costs
+   ~1 FD, so this is cheap. **Default 128, configurable.**
+3. **`render_ahead`** — bounded prefetch queue of decoded-but-unsubmitted page
+   images, in **pages**. This is the real memory bound (decoded bitmaps are
+   ~15-20 MB each at the small profile). Cap ≈ `max_in_flight_requests`,
+   independent of document count.
+
+### FD and memory accounting
+
+- FD pressure is dominated by **sockets** (= `max_in_flight_requests`, e.g. 512),
+  not open PDFs (128 FDs is noise). The 512 default exceeds the common
+  `ulimit -n 1024` once sockets + PDF handles + state writes + stdio are summed —
+  **docs must instruct raising the FD limit** and note the `max-num-seqs`
+  relationship.
+- Memory is bounded by `render_ahead` (decoded pages), **not** by document count.
+  Rendering stays **lazy** (file open, `render_page(n)` on demand, one image at a
+  time) — never eager-decode-whole-document-then-close, which trades 1 FD of
+  savings for multi-GB of RAM and scales with the largest document seen.
+
+## Protecting the server (OOM avoidance)
+
+Over-sending to a self-hosted VLM server can OOM it (olmOCR's "too many asyncio
+workers" failure). The cliff is **death, not degradation** — once the engine
+OOMs, no client retry policy recovers it; it needs a restart. So we stay under
+the memory ceiling by construction and probe gently.
+
+**Mechanism.** Two populations consume memory differently:
+- *Active batch* (vLLM is prefilling/decoding) — bounded by `max_num_seqs` /
+  `max_num_batched_tokens`; holds vision-tower activations in **VRAM**. This is
+  the OOM cliff, owned **server-side**.
+- *Waiting queue* (admitted, not scheduled) — holds raw image bytes in **host
+  RAM**, not GPU activations. Cheap; this is what client concurrency controls.
+
+So client concurrency cannot cause a GPU OOM *by itself once `max_num_seqs` is
+sized to fit VRAM* — it only sets queue depth. OOM means the server config is
+wrong, a shared GPU, or eager multimodal preprocessing in some vLLM versions.
+
+**Four layers of protection:**
+
+1. **Conservative-but-fed default** — `max_in_flight_requests = 4 × max_num_seqs`
+   (above), so the GPU never starves while surplus waits cheaply in host RAM.
+2. **Adaptive concurrency (AIMD)** — drive the semaphore size dynamically:
+   additive-increase on sustained success/low latency up to the 4× ceiling,
+   **multiplicative-decrease toward a floor of ~`max_num_seqs`** on any true
+   overload signal (429/503/timeout/connection-reset). Wire the existing
+   `ProviderOverloadController` to resize the semaphore, not just gate retry
+   timing. AIMD floats *below* the default; its job is snap-back, not ramp-up.
+   **Signal hygiene:** only genuine overload shrinks concurrency — a content
+   `400` or parse/verify rejection must NEVER throttle (else a mojibake-heavy run
+   self-throttles against a healthy server).
+3. **Circuit breaker + timeouts** — `ProviderOverloadController.circuit_open`
+   trips after N consecutive overloads: stop sending, let the server drain, then
+   probe. Per-request timeouts feed the AIMD decrease.
+4. **Server-side hardening (the real cliff-guard)** — operator config, surfaced
+   by `doctor` where observable and documented next to the `max-num-seqs` note:
+   `--gpu-memory-utilization ≈ 0.85` (headroom for multimodal activations),
+   right-sized `--max-num-seqs`, bounded `--max-model-len` and request
+   `max_tokens` (caps KV per sequence), `--limit-mm-per-prompt`,
+   `--max-num-batched-tokens` (bounds prefill spikes). The client default
+   *assumes* these are set; layers 1–3 survive the cases where they aren't.
+
+## Durability under concurrency
+
+- **Results are write-through.** Each succeeded page is written to its durable
+  artifact on disk first (unchanged from today); an in-RAM copy is at most a
+  *cache* to skip the re-read in `_assemble_if_ready`. **Never RAM-primary** — a
+  RAM-only result is lost on crash and defeats the ledger/resume contract.
+- **Single serialized state-writer for the compact indexes (chosen: Option A).**
+  `_write_indexes` rewrites the entire status index with an `fsync` on every
+  transition; under concurrency that both loses updates (workers clobbering each
+  other's whole-file rewrites) and creates an O(N²) fsync storm. Resolution:
+  - Workers **never write the indexes**. They push tiny events
+    `(page_number, new_state, fingerprint, diagnostic?)` onto an `asyncio.Queue`.
+  - **One writer task** owns the authoritative in-memory `pages`, folds each event
+    in (O(1)), and regenerates **all three** indexes (`status`/`resume`/`reconcile`)
+    together so they stay mutually consistent.
+  - **Coalesced flush cadence:** flush on `max(64 events, 250 ms)`, whichever
+    first, plus an **immediate flush on notable events** (terminal failure, settle,
+    job completion). Bounds index staleness to ≤250 ms; collapses the fsync storm
+    by ~100×.
+  - **Index writes are atomic but NOT fsync'd.** The durable truth (artifact +
+    per-attempt ledger) is fsync'd by workers per page; the indexes are a *derived,
+    rebuildable rollup*, so they need atomicity (`os.replace`, no torn reads) but
+    not durability. Losing the last index write on power-loss is harmless — resume
+    rebuilds it. Sharp rule: **fsync the truth (artifact, ledger); atomic-but-
+    unsynced the derived cache (indexes).**
+  - `run()`/`resume()` do a **final synchronous flush** before returning, and the
+    returned `JobStatus` comes from the writer's in-memory snapshot (never a stale
+    read).
+- **The compact index is now formally eventually-consistent.** This leans into the
+  codebase's existing intent: the index is already called *compact*, already has
+  `repair_index` to rebuild it from artifacts, and `fsck` to triangulate it. The
+  per-page **artifact + per-attempt ledger** are the source of truth and are
+  already per-file concurrency-safe.
+- **Resume reconciles before processing.** Because the index may lag the truth
+  after a crash, `resume` first runs a reconcile pass (`repair_index` semantics
+  fused with adopt-then-requeue: artifact present + fingerprint match →
+  `succeeded`) so processing sees real state — turning index staleness into a cheap
+  reconcile, never lost or duplicated durable work.
+- **Out-of-order completion is fine.** `_assemble_if_ready` sorts by page number
+  and only assembles when complete (or `allow_partial`); pages may finish in any
+  order.
+
+## Resolved
+
+- **State-writer mechanism** — Option A (single coalescing writer), see
+  "Durability under concurrency".
+- **Backpressure / retry-storm under load** — see "Protecting the server".
+
+## Multi-process claim tier (single machine)
+
+Scope: **always a single machine**, multiple `paperscale` processes pulling work.
+No cross-machine / NFS / object-store backends — explicitly YAGNI.
+
+- **Unit of claim: the document/job**, not the page. Each job is single-owner, so
+  the entire intra-process design (single index writer, async pool, backpressure)
+  runs unchanged within it. Horizontal scale = many documents across processes.
+  A single gigantic document is handled by **sharding into sub-jobs at ingest**
+  (page ranges, assembled at the end), never by multiple processes on one job.
+- **Claim substrate: `O_EXCL` filesystem ClaimStore.** Atomic on a local fs, so
+  claims are genuinely exclusive between processes. A document-level claim record
+  `jobs/<job_id>/claim.json` carries `worker_id`, `epoch`, `lease_expires_at`,
+  `heartbeat_at`. (A `ClaimStore` seam may exist, but only the `O_EXCL`
+  implementation is needed — no pluggable multi-machine backends.)
+- **Lease 60 s, heartbeat 20 s** (≈ lease/3). Owner renews via heartbeat; a silent
+  owner past `lease_expires_at` is reclaimed by another process with a **higher
+  epoch**.
+- **Correctness does NOT rest on the lock.** A lease/epoch on plain storage gives
+  efficient, mostly-exclusive claims + crash reclaim — **not** hard mutual
+  exclusion: a paused (not dead) owner can wake after takeover and still write,
+  and a dumb filesystem cannot fence that write (`os.replace` lands last-write-
+  wins). Safety rests on two enforceable things instead:
+  1. **D2 idempotency** — page-keyed, deterministic artifacts mean a zombie write
+     is *redundant, not corrupting*. This is what makes the unenforceable fence
+     tolerable, and it lets leases be short (false takeover = wasted work, never
+     wrong work) without padding for worst-case GC pauses.
+  2. **Epoch-aware reconcile (read-side fencing)** — every page attempt stamps the
+     **owner's claim epoch**; the index writer / recovery ignores attempts from a
+     superseded epoch. The fence moves from "prevent the write" (impossible) to
+     "reject the stale write on read" (enforceable by the single higher-epoch
+     owner). Composes with the eventually-consistent derived index: a brief
+     two-owner overlap just yields a stale index the higher-epoch owner overwrites
+     and resume reconciles.
+- **Completion markers.** On true completion (all pages succeeded + assembled),
+  write a **durable, fsync'd `done` marker** — truth, unlike the eventually-
+  consistent index. The claim path checks the marker before attempting a claim, so
+  finished documents are skipped without re-claiming. The marker joins
+  artifact + ledger on the fsync-the-truth side of the split.

--- a/docs/ledger-recovery.md
+++ b/docs/ledger-recovery.md
@@ -29,4 +29,24 @@ writes belong in the state-store implementation.
 
 Ambiguous work should be surfaced with page IDs and duplicate-call risk. The
 ledger intentionally raises `AmbiguousAttemptError` by default to prevent silent
-provider replays against non-idempotent endpoints.
+provider replays against non-idempotent endpoints. Operators resolve ambiguous
+pages with `reconcile --supersede PAGE` (discard the uncertain attempt, requeue)
+or `reconcile --accept PAGE` (adopt the page's already-written artifact); both
+record the prior attempt as `superseded`.
+
+## Resource governance and capacity
+
+The real `DocumentOcrRunner` processes pages sequentially under a
+`ResourceGovernor`, which enforces the global acquisition order
+`scheduler -> render -> provider -> page_lease -> state_store`. Persistence is
+governed at `state_store_lock` granularity; the state store owns its own
+transient file descriptors.
+
+Provider pressure is controlled by the capacity profile resolved from
+`manifest.capacity` (`builtin_capacity_profile`). Transient provider transport
+errors are retried with exponential backoff (`backoff_initial_seconds` doubling
+up to `backoff_max_seconds`). After `circuit_breaker_failure_threshold`
+consecutive failures the circuit opens: the run stops and any pages not yet
+started stay `pending`, so a later `paperscale resume` continues the work.
+Content failures (parse/verify rejections) are classified by the profile and are
+not retried within a single run.

--- a/docs/recovery-retry-redesign.md
+++ b/docs/recovery-retry-redesign.md
@@ -1,0 +1,152 @@
+# Recovery and Retry Redesign
+
+Status: **implemented**. Supersedes the *default* recovery behavior described in
+`ledger-recovery.md` (ambiguous-by-default). The ledger state machine and
+`ambiguous`/`reconcile` machinery are retained but become opt-in for metered
+endpoints (`--metered`). See `runner.py` (`_recover_expired_attempts`,
+`_process_one_page`, `_demote_terminal`), `profiles/base.py:ModelOcrProfile.remediation_for`,
+and tests in `tests/test_recovery_retry_redesign.py`.
+
+Implementation extensions (to make every document complete, validated at 233/233
+pages over 30 scanned law PDFs against a real DeepSeek-OCR-2 server):
+- **Rendering uses PDFium** (`pypdfium2`), which rasterizes scanned ImageMask/CCITT
+  pages that the old `pdf_oxide` backend skipped (blank image → empty OCR).
+- **`empty_output` joins the render-remediation set** — an empty completion on a
+  content page re-renders at higher DPI rather than re-rolling identically.
+- **Blank-page acceptance** — a near-blank render (`png_dark_fraction` below
+  `_BLANK_INK_THRESHOLD`) whose OCR yields no readable content (empty, or a VLM
+  repetition loop on noise) is committed as a *successful empty page*, so a blank
+  separator page never strands a job at `failed_terminal`. The ink gate ensures real
+  content pages still remediate normally.
+
+## Motivation
+
+The v1 recovery contract escalates every crashed `in_flight` page to
+`ambiguous`, blocking on an operator to avoid a duplicate provider call. That
+contract assumes provider calls carry a billable or non-idempotent side effect.
+Paperscale's primary target is **self-hosted** inference (a local vLLM endpoint,
+`api_key="paperscale-local"`), where a duplicate call costs only GPU time and
+latency. Page output is idempotent: artifacts are keyed by page number and the
+content is deterministic for a given image + profile, so a re-call cannot
+corrupt the document. The redesign optimizes for "never block on a human" and
+treats duplicate-call avoidance as the exceptional, metered-only case.
+
+## Decisions
+
+1. **Auto-requeue by default.** A crashed `in_flight` page with an expired lease
+   recovers to `pending` and is retried on the next `run`/`resume`. The
+   `ambiguous` state is no longer the default outcome.
+
+2. **Duplicate calls are idempotent.** Re-calling the provider for an
+   already-attempted page cannot harm correctness — artifacts are page-keyed and
+   content-deterministic. The only cost is GPU/latency. This is the premise that
+   makes auto-requeue safe.
+
+3. **`metered` is a transient switch.** A `metered: bool = False` flag on
+   `RunnerConfig`, set by a `--metered` CLI flag, restores the ambiguous-on-crash
+   behavior for billable/non-idempotent endpoints. It is **not** persisted in the
+   manifest: `resume` reads the live flag, so metered-safety depends on operator
+   discipline at every invocation. This is an accepted tradeoff for a
+   self-hosted-first tool; it is a choice, not an oversight.
+
+4. **Adopt-then-requeue on recovery.** The provider call is the last slow step
+   before the artifact is committed, so the most likely crash window is *after*
+   the artifact is durably written but *before* the index records `succeeded`.
+   Recovery of an `in_flight` page therefore:
+   - if the artifact file exists **and** its `fingerprint` matches the attempt's
+     fingerprint → adopt it, mark `succeeded`, trigger assembly (zero provider
+     calls);
+   - else → `pending` (or `ambiguous` when `metered`).
+
+   The fingerprint match proves the artifact came from *this* attempt's exact
+   request, not a stale/superseded epoch. This mirrors the existing
+   `repair_index` adoption logic.
+
+5. **Adoption is safe because writes are atomic.** A present artifact is always
+   complete: `write_json_atomic` writes a temp file, `fsync`s it, then
+   `os.replace`s into place — a reader sees either nothing or the fully-written
+   file, never a torn one. `ensure_known_schema` fail-closes on read. The
+   parent-directory `fsync` exists to make the *rename durable* (not lose a
+   commit on power loss), not to prevent torn reads.
+
+6. **Hard retry cap of 8.** `max_attempts: int = 8` on `RunnerConfig`. The
+   per-page `epoch` becomes load-bearing: once attempts exceed the cap, a
+   `failed_retryable` page is demoted to `failed_terminal` with a diagnostic.
+   Without this, a deterministically-bad page (e.g. an unreadable scan producing
+   mojibake) is `retryable` forever and re-calls the provider on every `resume`.
+   Refusals remain terminal on first sight (re-rolling identical input is
+   provably futile).
+
+7. **Automatic diagnostic-driven remediation.** The 8 attempts are not identical
+   re-rolls. Each failure's `diagnostic` (already persisted on the page entry)
+   drives an escalating remediation on the next attempt, via a
+   diagnostic → overrides table **owned by the profile** (only the profile
+   understands its own decoding/render semantics):
+
+   | diagnostic | remediation |
+   |---|---|
+   | `truncation_indicator`, `length_anomaly` (too long) | increase decoding token budget |
+   | `mojibake`, `control_characters` | re-render at higher DPI |
+   | `repeated_ngram`, `repeated_character` | raise `repetition_penalty` / nudge temperature |
+   | unknown | identity (plain re-roll) |
+
+   Each remediation changes the request fingerprint — intentional: the ledger
+   records exactly which remediation produced the eventual success, and
+   adopt-then-requeue (Decision 4) still matches per attempt.
+
+8. **Remediations accumulate.** Overrides layer additively across attempts rather
+   than being rebuilt from base on each failure. Reacting only to the *last*
+   diagnostic would discard prior fixes (e.g. a token bump for `truncation` would
+   reset a DPI bump from an earlier `mojibake`) and could oscillate without
+   converging. This requires persisting the effective `decoding`/`render_options`
+   (or an ordered remediation list) on the page entry, so a crash mid-ladder
+   resumes with corrections intact. Each dimension has a ceiling (max DPI, max
+   token budget) so monotonic escalation cannot exceed provider/image limits; the
+   8-attempt cap is the outer backstop. No per-dimension early-terminal logic for
+   now (YAGNI).
+
+9. **No schema bump.** All additions (accumulated overrides, carried per-page
+   state) are additive and optional, read with `.get(key, default)`. The
+   fail-closed guard rejects only `schema_version > current`; unfamiliar fields
+   are tolerated. Old jobs lack remediation history and correctly default to the
+   base profile. Stays `schema_version = 1`. Discipline: additive+optional → same
+   version; required-or-breaking → bump. Never read a new field with `payload[key]`.
+
+## Code touchpoints
+
+- `runner.py:_recover_expired_attempts` — branch on `self.config.metered`; add the
+  adopt path (check `_artifact_rel` existence + fingerprint match before requeue).
+- `runner.py:_process_pages` — read `epoch` + accumulated overrides at the top;
+  demote to `failed_terminal` at the cap; build the request from
+  `profile.with_overrides(...)`.
+- `profiles/base.py:ModelOcrProfile` — new `remediation_for(diagnostic) -> overrides`
+  table; per-dimension ceilings.
+- `runner.py:_write_indexes` — carry `overrides` (or remediation list) on the page
+  entry alongside `epoch`/`diagnostic`.
+- `runner.py:RunnerConfig` — add `metered: bool = False`, `max_attempts: int = 8`.
+- `cli.py` — `--metered` flag on `run`/`resume`; `--max-attempts` if exposed.
+
+## Completion and settling
+
+10. **Terminal pages keep hard-failing (for now).** A `failed_terminal` page
+    (refusal, or 8-exhaustion) blocks `JobStatus.complete`; the job assembles
+    output only when the operator passes `--allow-partial`. No auto-degrade to
+    partial-complete. Deferred, not rejected — revisit if the no-human-block
+    philosophy wins out.
+
+11. **Minimal settled-reporting.** Even under hard-fail, `status`/`resume` must
+    distinguish **settled-with-failures** (no `pending`/`failed_retryable`/
+    `in_flight`/`reserved` pages remain — only `succeeded` + terminal, so resume
+    cannot progress) from **has-retryable-work** (resume will make progress).
+    This is a *reporting-only* change: no partial output is written without
+    `--allow-partial`, exit stays non-zero, but the message becomes actionable —
+    e.g. `job X: settled with 1 terminal failure (page 137); resume will not
+    progress — pass --allow-partial to assemble 199/200, or re-source page 137`.
+    Without it, a settled job's `resume` is an infinite silent no-op
+    indistinguishable from a job that is still progressing.
+
+### Additional code touchpoint
+
+- `runner.py:JobStatus` / `_write_indexes` — derive a `settled` boolean (no
+  pending/retryable/in_flight/reserved pages) from the counts already computed;
+  surface it in `status`/`resume` messaging and exit-code selection.

--- a/docs/state-layout.md
+++ b/docs/state-layout.md
@@ -1,0 +1,63 @@
+# State layout: `.paperscale/jobs/<job_id>`
+
+Every job writes its durable state under the `--state-root` directory (default
+`.paperscale`). The assembled Markdown goes to the `--output` path you choose and
+lives outside this tree. All internal files are written atomically (temp file,
+fsync, rename) and carry a `schema_version`; the runner refuses to read a version
+it does not understand.
+
+```
+.paperscale/
+└── jobs/
+    └── <job_id>/
+        ├── manifest.json            # immutable job description
+        ├── indexes/
+        │   ├── status.json          # per-page state + summary counts
+        │   ├── resume.json          # pending / ambiguous / in-flight page lists
+        │   └── reconcile.json       # ambiguous attempts + recommended actions
+        ├── ledger/
+        │   └── <attempt_id>.json    # one file per page attempt (latest state)
+        └── artifacts/
+            └── pages/
+                └── <page_number>.json   # committed Markdown for a succeeded page
+```
+
+## `manifest.json`
+
+Written once when the job is created and never mutated. Records the input and
+output paths, `document_id`, `page_count`, and the `profile`, `base_url`,
+`model`, and `capacity` the job runs with. `resume` reads these so it continues
+with the original settings.
+
+## `indexes/`
+
+Compact indexes let `status`, `resume`, and `reconcile` answer without scanning
+the artifact tree.
+
+- **`status.json`** — the authority for per-page state. Holds a `pages` map
+  (`"<n>" -> {state, epoch, attempt_id, fingerprint, ...}`) plus summary counts
+  (`succeeded`, `pending`, `failed_retryable`, `failed_terminal`, `ambiguous`,
+  `in_flight`). Page states: `pending`, `reserved`, `in_flight`, `succeeded`,
+  `failed_retryable`, `failed_terminal`, `ambiguous`, `superseded`.
+- **`resume.json`** — pages grouped into `pending_pages`, `ambiguous_pages`, and
+  `in_flight_pages` for fast resume planning.
+- **`reconcile.json`** — `ambiguous_attempts`, each with its `page_number`,
+  `attempt_id`, `duplicate_call_risk`, and `recommended_actions`
+  (`["supersede", "accept"]`).
+
+## `ledger/`
+
+One file per page attempt, named by `attempt_id`. The runner reserves and
+persists an attempt **before** any provider I/O, marks it `in_flight` before the
+request can commit, and writes the terminal state afterward. This ordering is the
+crash-safety contract: a `reserved` attempt with no provider start requeues to
+`pending` after its lease expires, while an `in_flight` attempt with no committed
+result becomes `ambiguous`. Each attempt carries an `epoch`; a higher-epoch
+takeover invalidates stale workers. See [ledger-recovery.md](ledger-recovery.md).
+
+## `artifacts/pages/`
+
+One file per succeeded page, named by page number. Holds the validated
+`markdown`, the request `fingerprint` and `image_hash`, provider metadata, and
+verifier metadata. A page counts as `succeeded` only when its artifact exists;
+`repair-index` and `fsck` rely on this to triangulate index against disk.

--- a/docs/superpowers/plans/2026-06-09-runner-resource-and-capacity.md
+++ b/docs/superpowers/plans/2026-06-09-runner-resource-and-capacity.md
@@ -1,0 +1,742 @@
+# Runner Resource Governance & Capacity Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the real `DocumentOcrRunner` page-processing path through `ResourceGovernor` (managed acquisition order) and `ProviderOverloadController` (retry/backoff/circuit-breaker driven by the job's capacity profile), closing issues #4 and #7.
+
+**Architecture:** Keep processing **sequential, one page at a time** (no threads — preserves the existing single-process durability model and matches `ResourceGovernor`'s inherently single-threaded acquisition stack). Each page acquires resources in the global order `scheduler → render → provider → page_lease → state_store`; persistence is governed at `state_store_lock` granularity (the store owns its own transient fds, so `file_descriptor` is intentionally not separately modeled for internal atomic writes). A `ProviderOverloadController`, constructed from `builtin_capacity_profile(manifest.capacity)`, retries transient provider transport errors with exponential backoff and trips a circuit breaker after the profile's failure threshold, at which point the run stops and leaves remaining pages `pending` for a later `resume`.
+
+**Tech Stack:** Python 3.12+, stdlib `unittest`, existing `paperscale.resources.ResourceGovernor`, `paperscale.providers.self_hosted.ProviderCapacityProfile`/`ProviderOverloadController`/`builtin_capacity_profile`.
+
+**Scope note:** `Scheduler`/`JobScheduler`/`LazyPageQueue` in `scheduler.py` are left untouched — they serve compact-index status reads on a different interface and add no behavior to a sequential runner. We adopt only the capacity profile + overload controller + governor.
+
+---
+
+## File Structure
+
+- **Modify** `src/paperscale/providers/self_hosted.py` — add `ProviderOverloadController.record_failure(*, retryable)` so exception-only providers (no HTTP status) can drive backoff/circuit logic.
+- **Modify** `src/paperscale/runner.py` — inject `ResourceGovernor` + sleeper; resolve capacity profile; wrap render/provider/state in governed acquisition order; add a retry/circuit loop in `_process_pages`; make `_process_page` return a `_PageOutcome`; route state writes through `state_store_lock`.
+- **Create** `tests/test_runner_scheduling.py` — governor ordering, retry/backoff, circuit-breaker behavior.
+- **Modify** `tests/providers/test_self_hosted.py` — `record_failure` unit tests.
+- **Modify** `docs/ledger-recovery.md` — short note documenting capacity/circuit behavior on the real runner.
+
+**Invariants to preserve (regression):** the existing happy-path runner tests (`tests/test_ocr_runner_cli_integration.py`), schema/fsck/reconcile tests, and the ledger-before-provider durability ordering must all stay green. The real `ResourceGovernor` *raises* `ResourceOrderViolation` on misordering, so a green run is itself proof the ordering is correct.
+
+---
+
+## Task 1: `ProviderOverloadController.record_failure`
+
+Exception-based providers can't call `record_status(code)`. Add a transport-agnostic failure accountant that mirrors the retryable-status branch.
+
+**Files:**
+- Modify: `src/paperscale/providers/self_hosted.py` (add method to `ProviderOverloadController`, after `record_status`, ~line 220)
+- Test: `tests/providers/test_self_hosted.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/providers/test_self_hosted.py` (reuse its existing imports; add a small capacity factory if one is not already present):
+
+```python
+def _capacity(threshold: int = 3, *, initial: float = 1.0, maximum: float = 8.0):
+    from paperscale.providers.self_hosted import ProviderCapacityProfile
+
+    return ProviderCapacityProfile(
+        name="test",
+        max_in_flight_requests=1,
+        max_provider_queue=1,
+        queue_size=1,
+        timeout_seconds=1.0,
+        backoff_initial_seconds=initial,
+        backoff_max_seconds=maximum,
+        circuit_breaker_failure_threshold=threshold,
+        circuit_breaker_cooldown_seconds=1.0,
+        render_target_longest_side=10,
+    )
+
+
+class RecordFailureTests(unittest.TestCase):
+    def test_retryable_failures_open_circuit_after_threshold(self) -> None:
+        from paperscale.providers.self_hosted import ProviderOverloadController
+
+        controller = ProviderOverloadController(_capacity(threshold=3))
+        first = controller.record_failure(retryable=True)
+        second = controller.record_failure(retryable=True)
+        third = controller.record_failure(retryable=True)
+        self.assertTrue(first.should_retry)
+        self.assertFalse(first.circuit_open)
+        self.assertTrue(second.should_retry)
+        self.assertTrue(third.circuit_open)
+        self.assertFalse(third.should_retry)
+
+    def test_backoff_grows_exponentially_then_caps(self) -> None:
+        from paperscale.providers.self_hosted import ProviderOverloadController
+
+        controller = ProviderOverloadController(_capacity(threshold=10, initial=1.0, maximum=8.0))
+        backoffs = [controller.record_failure(retryable=True).backoff_seconds for _ in range(5)]
+        self.assertEqual(backoffs, [1.0, 2.0, 4.0, 8.0, 8.0])
+
+    def test_non_retryable_failure_resets_consecutive_count(self) -> None:
+        from paperscale.providers.self_hosted import ProviderOverloadController
+
+        controller = ProviderOverloadController(_capacity(threshold=2))
+        controller.record_failure(retryable=True)
+        decision = controller.record_failure(retryable=False)
+        self.assertFalse(decision.should_retry)
+        self.assertFalse(controller.circuit_open)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `poetry run pytest tests/providers/test_self_hosted.py -q`
+Expected: FAIL — `AttributeError: 'ProviderOverloadController' object has no attribute 'record_failure'`
+
+- [ ] **Step 3: Implement `record_failure`**
+
+In `src/paperscale/providers/self_hosted.py`, add this method to `ProviderOverloadController` immediately after `record_status`:
+
+```python
+    def record_failure(self, *, retryable: bool) -> BackoffDecision:
+        """Account for a provider transport failure surfaced as an exception.
+
+        Transport-agnostic counterpart to record_status: callers that only see
+        exceptions (no HTTP status) use this to drive backoff and the circuit breaker.
+        """
+        if not retryable:
+            self._consecutive_failures = 0
+            return BackoffDecision(False, 0.0, False, "non-retryable provider error")
+        self._consecutive_failures += 1
+        backoff = min(
+            self.capacity.backoff_initial_seconds * (2 ** (self._consecutive_failures - 1)),
+            self.capacity.backoff_max_seconds,
+        )
+        return BackoffDecision(
+            should_retry=not self.circuit_open,
+            backoff_seconds=backoff,
+            circuit_open=self.circuit_open,
+            diagnostic="provider transport error",
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `poetry run pytest tests/providers/test_self_hosted.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/paperscale/providers/self_hosted.py tests/providers/test_self_hosted.py
+git commit -m "feat(provider): add transport-agnostic record_failure to overload controller"
+```
+
+---
+
+## Task 2: Runner scaffolding — inject governor + sleeper, govern state writes (no behavior change)
+
+Wire the governor and sleeper into the runner and route the three persistence primitives through `state_store_lock`. This task is a **pure refactor**: all existing tests must stay green afterward, proving the governance is transparent on the happy path.
+
+**Files:**
+- Modify: `src/paperscale/runner.py` (imports ~line 15-28; `__init__` line 145; `_write_indexes` line 607; `_write_ledger` line 652; `_write_manifest` line 582; add `_PageOutcome` + `_capacity_for`)
+
+- [ ] **Step 1: Add imports**
+
+In `src/paperscale/runner.py`, extend the `self_hosted` import and add the resources import. Replace:
+
+```python
+from paperscale.providers.self_hosted import (
+    InferenceServerProfile,
+    SelfHostedOpenAICompatibleProvider,
+    builtin_capacity_profile,
+)
+```
+
+with:
+
+```python
+from paperscale.providers.self_hosted import (
+    InferenceServerProfile,
+    ProviderCapacityProfile,
+    ProviderOverloadController,
+    SelfHostedOpenAICompatibleProvider,
+    builtin_capacity_profile,
+)
+from paperscale.resources import ResourceGovernor, ResourceKind
+```
+
+- [ ] **Step 2: Add the `_PageOutcome` dataclass**
+
+Add near the top of `runner.py`, just after the `RendererFactory = ...` alias (~line 31):
+
+```python
+@dataclass(frozen=True, slots=True)
+class _PageOutcome:
+    """Result of a single page attempt, used to drive retry/circuit decisions."""
+
+    status: str  # "succeeded" | "transport_error" | "content_failure"
+```
+
+- [ ] **Step 3: Extend `__init__` to inject governor + sleeper**
+
+Replace the current `__init__` signature/body (line 145):
+
+```python
+    def __init__(
+        self,
+        config: RunnerConfig | None = None,
+        *,
+        provider: PageOcrProvider | None = None,
+        renderer_factory: RendererFactory | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self.config = config or RunnerConfig()
+        self.state = FileSystemStateStore(Path(self.config.state_root))
+        self.provider = provider
+        self.renderer_factory = renderer_factory or (lambda path, options: PdfPageRenderer(path, render_options=options))
+        self.clock = clock or time.time
+        self.verifier = DeterministicQualityVerifier()
+```
+
+with:
+
+```python
+    def __init__(
+        self,
+        config: RunnerConfig | None = None,
+        *,
+        provider: PageOcrProvider | None = None,
+        renderer_factory: RendererFactory | None = None,
+        clock: Callable[[], float] | None = None,
+        governor: ResourceGovernor | None = None,
+        sleeper: Callable[[float], None] | None = None,
+    ) -> None:
+        self.config = config or RunnerConfig()
+        self.state = FileSystemStateStore(Path(self.config.state_root))
+        self.provider = provider
+        self.renderer_factory = renderer_factory or (lambda path, options: PdfPageRenderer(path, render_options=options))
+        self.clock = clock or time.time
+        self.verifier = DeterministicQualityVerifier()
+        self.governor = governor or ResourceGovernor()
+        self._sleep = sleeper or time.sleep
+```
+
+- [ ] **Step 4: Add `_capacity_for` helper**
+
+Add this method to `DocumentOcrRunner` (place it just above `_process_pages`, ~line 395):
+
+```python
+    def _capacity_for(self, manifest: JobManifest) -> ProviderCapacityProfile:
+        try:
+            return builtin_capacity_profile(manifest.capacity)
+        except ValueError:
+            return builtin_capacity_profile("local-vllm-small")
+```
+
+- [ ] **Step 5: Govern the persistence primitives**
+
+Replace `_write_ledger` (line 652):
+
+```python
+    def _write_ledger(self, job_id: str, attempt_id: str, payload: Json) -> None:
+        self.state.write_json_atomic(self._ledger_rel(job_id, attempt_id), payload)
+```
+
+with:
+
+```python
+    def _write_ledger(self, job_id: str, attempt_id: str, payload: Json) -> None:
+        with self.governor.acquire(ResourceKind.STATE_STORE):
+            self.state.write_json_atomic(self._ledger_rel(job_id, attempt_id), payload)
+```
+
+Replace `_write_manifest` (line 582):
+
+```python
+    def _write_manifest(self, manifest: JobManifest) -> None:
+        self.state.write_json_atomic(self._manifest_rel(manifest.job_id), manifest.to_json())
+```
+
+with:
+
+```python
+    def _write_manifest(self, manifest: JobManifest) -> None:
+        with self.governor.acquire(ResourceKind.STATE_STORE):
+            self.state.write_json_atomic(self._manifest_rel(manifest.job_id), manifest.to_json())
+```
+
+In `_write_indexes` (line 607), replace the three-write tail:
+
+```python
+        self.state.write_json_atomic(self._index_rel(manifest.job_id, "status"), status_index)
+        self.state.write_json_atomic(self._index_rel(manifest.job_id, "resume"), resume_index)
+        self.state.write_json_atomic(self._index_rel(manifest.job_id, "reconcile"), reconcile_index)
+        return JobStatus.from_index(status_index)
+```
+
+with:
+
+```python
+        with self.governor.acquire(ResourceKind.STATE_STORE):
+            self.state.write_json_atomic(self._index_rel(manifest.job_id, "status"), status_index)
+            self.state.write_json_atomic(self._index_rel(manifest.job_id, "resume"), resume_index)
+            self.state.write_json_atomic(self._index_rel(manifest.job_id, "reconcile"), reconcile_index)
+        return JobStatus.from_index(status_index)
+```
+
+- [ ] **Step 6: Run the full suite to verify no behavior change**
+
+Run: `poetry run pytest -q`
+Expected: PASS — same count as before this plan (governance is transparent here; `STATE_STORE` acquired on an empty stack never violates order).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/paperscale/runner.py
+git commit -m "refactor(runner): inject ResourceGovernor/sleeper and govern state writes"
+```
+
+---
+
+## Task 3: Govern render/provider/scheduler order and return a `_PageOutcome`
+
+Wrap rendering and the provider attempt in the correct acquisition order and make `_process_page` report what happened.
+
+**Files:**
+- Modify: `src/paperscale/runner.py` (`_process_pages` line 395; `_process_page` line 431)
+- Test: `tests/test_runner_scheduling.py` (create)
+
+- [ ] **Step 1: Write the failing ordering test**
+
+Create `tests/test_runner_scheduling.py`:
+
+```python
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from paperscale.providers.base import PageOcrResponse, ProviderError
+from paperscale.resources import ResourceGovernor, ResourceKind
+from paperscale.runner import DocumentOcrRunner, RunnerConfig
+
+
+@dataclass(frozen=True)
+class _FakeRenderedPage:
+    page_number: int
+    image_bytes: bytes
+    image_hash: str
+    media_type: str = "image/png"
+
+
+class _FakeRenderer:
+    def __init__(self, pages: list[bytes]) -> None:
+        self._pages = pages
+
+    @property
+    def page_count(self) -> int:
+        return len(self._pages)
+
+    def render_page(self, page_number: int) -> _FakeRenderedPage:
+        image = self._pages[page_number - 1]
+        return _FakeRenderedPage(page_number, image, hashlib.sha256(image).hexdigest())
+
+
+class _ScriptedProvider:
+    """Provider that raises ProviderError for the first `fail_first` calls, then succeeds."""
+
+    name = "scripted"
+
+    def __init__(self, *, fail_first: int = 0, always_fail: bool = False) -> None:
+        self.fail_first = fail_first
+        self.always_fail = always_fail
+        self.calls = 0
+
+    def send(self, request: Any) -> PageOcrResponse:
+        self.calls += 1
+        if self.always_fail or self.calls <= self.fail_first:
+            raise ProviderError(f"boom {self.calls}")
+        return PageOcrResponse(markdown=f"# Page\n\nBody {request.page_id}", provider_request_id=request.fingerprint)
+
+
+class RecordingGovernor(ResourceGovernor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.acquired: list[ResourceKind | str] = []
+
+    def acquire(self, kind: ResourceKind | str):  # type: ignore[override]
+        self.acquired.append(kind)
+        return super().acquire(kind)
+
+
+def _runner(state_root: Path, provider: Any, *, governor: Any = None, sleeper: Any = None, capacity: str = "local-vllm-small") -> DocumentOcrRunner:
+    return DocumentOcrRunner(
+        RunnerConfig(state_root=state_root, base_url="http://fake/v1", model="mock-vlm", capacity=capacity),
+        provider=provider,
+        renderer_factory=lambda _path, _options: _FakeRenderer([b"page-1"]),
+        governor=governor,
+        sleeper=sleeper,
+    )
+
+
+class GovernedOrderingTests(unittest.TestCase):
+    def test_page_processing_acquires_resources_in_global_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            governor = RecordingGovernor()
+            runner = _runner(state_root, _ScriptedProvider(), governor=governor)
+            status = runner.run(input_path=state_root / "in.pdf", output_path=state_root / "out.md", job_id="job")
+            self.assertEqual(status.succeeded, 1)
+            # Real ResourceGovernor raises on misordering, so a clean run is proof.
+            # Assert the key managed resources were actually acquired (not bypassed).
+            self.assertIn(ResourceKind.SCHEDULER, governor.acquired)
+            self.assertIn(ResourceKind.RENDER, governor.acquired)
+            self.assertIn(ResourceKind.PROVIDER, governor.acquired)
+            self.assertIn(ResourceKind.PAGE_LEASE, governor.acquired)
+            self.assertIn(ResourceKind.STATE_STORE, governor.acquired)
+            # render is acquired before provider for the same page
+            self.assertLess(
+                governor.acquired.index(ResourceKind.RENDER),
+                governor.acquired.index(ResourceKind.PROVIDER),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `poetry run pytest tests/test_runner_scheduling.py::GovernedOrderingTests -q`
+Expected: FAIL — `ResourceKind.SCHEDULER` (and others) not in `governor.acquired`, because the current runner never touches the governor in the processing path.
+
+- [ ] **Step 3: Rewrite `_process_pages`**
+
+Replace the body of `_process_pages` (line 395):
+
+```python
+    def _process_pages(
+        self,
+        manifest: JobManifest,
+        pages: Json,
+        *,
+        renderer: Any,
+        allow_partial: bool,
+        retry_ambiguous: bool,
+    ) -> JobStatus:
+        profile = get_builtin_profile(manifest.profile)
+        for page_number in range(1, manifest.page_count + 1):
+            page = pages[str(page_number)]
+            state = page.get("state")
+            if state == "succeeded":
+                continue
+            if state == "ambiguous" and not retry_ambiguous:
+                continue
+            if state not in {"pending", "failed_retryable", "reserved", "ambiguous"}:
+                continue
+            rendered = renderer.render_page(page_number)
+            request = profile.build_request(
+                f"{manifest.document_id}:{page_number}",
+                rendered.image_bytes,
+                getattr(rendered, "media_type", "image/png"),
+                model=manifest.model,
+            )
+            self._process_page(manifest, pages, page_number, request)
+        self._assemble_if_ready(manifest, pages, allow_partial=allow_partial)
+        return self._write_indexes(manifest, pages, partial=allow_partial and _count_states(pages).get("succeeded", 0) < manifest.page_count)
+```
+
+with:
+
+```python
+    def _process_pages(
+        self,
+        manifest: JobManifest,
+        pages: Json,
+        *,
+        renderer: Any,
+        allow_partial: bool,
+        retry_ambiguous: bool,
+    ) -> JobStatus:
+        profile = get_builtin_profile(manifest.profile)
+        capacity = self._capacity_for(manifest)
+        overload = ProviderOverloadController(capacity)
+        for page_number in range(1, manifest.page_count + 1):
+            if overload.circuit_open:
+                break
+            page = pages[str(page_number)]
+            state = page.get("state")
+            if state == "succeeded":
+                continue
+            if state == "ambiguous" and not retry_ambiguous:
+                continue
+            if state not in {"pending", "failed_retryable", "reserved", "ambiguous"}:
+                continue
+            with self.governor.acquire(ResourceKind.SCHEDULER):
+                with self.governor.acquire(ResourceKind.RENDER):
+                    rendered = renderer.render_page(page_number)
+                request = profile.build_request(
+                    f"{manifest.document_id}:{page_number}",
+                    rendered.image_bytes,
+                    getattr(rendered, "media_type", "image/png"),
+                    model=manifest.model,
+                )
+                while True:
+                    outcome = self._process_page(manifest, pages, page_number, request)
+                    if outcome.status != "transport_error":
+                        if outcome.status == "succeeded":
+                            overload.record_success()
+                        break
+                    decision = overload.record_failure(retryable=True)
+                    if not decision.should_retry:
+                        break
+                    self._sleep(decision.backoff_seconds)
+        self._assemble_if_ready(manifest, pages, allow_partial=allow_partial)
+        return self._write_indexes(manifest, pages, partial=allow_partial and _count_states(pages).get("succeeded", 0) < manifest.page_count)
+```
+
+- [ ] **Step 4: Rewrite `_process_page` to govern provider/lease and return `_PageOutcome`**
+
+Replace the entire `_process_page` method (lines 431-521):
+
+```python
+    def _process_page(self, manifest: JobManifest, pages: Json, page_number: int, request: Any) -> _PageOutcome:
+        page_key = str(page_number)
+        previous = pages[page_key]
+        epoch = int(previous.get("epoch") or 0) + 1
+        attempt_id = str(uuid.uuid4())
+        now = float(self.clock())
+        with self.governor.acquire(ResourceKind.PROVIDER):
+            with self.governor.acquire(ResourceKind.PAGE_LEASE):
+                attempt = {
+                    "schema_version": CURRENT_SCHEMA_VERSION,
+                    "kind": "page_attempt",
+                    "attempt_id": attempt_id,
+                    "job_id": manifest.job_id,
+                    "page_id": request.page_id,
+                    "page_number": page_number,
+                    "state": "reserved",
+                    "fingerprint": request.fingerprint,
+                    "worker_id": self.config.worker_id,
+                    "epoch": epoch,
+                    "lease_expires_at": now + self.config.lease_seconds,
+                    "heartbeat_at": now,
+                    "provider_started_at": None,
+                    "provider_response_committed_at": None,
+                    "result_pointer": None,
+                    "diagnostic": None,
+                }
+                self._write_ledger(manifest.job_id, attempt_id, attempt)
+                pages[page_key] = {
+                    "state": "reserved",
+                    "epoch": epoch,
+                    "attempt_id": attempt_id,
+                    "fingerprint": request.fingerprint,
+                }
+                self._write_indexes(manifest, pages, partial=False)
+
+                attempt = {**attempt, "state": "in_flight", "provider_started_at": float(self.clock())}
+                self._write_ledger(manifest.job_id, attempt_id, attempt)
+                pages[page_key] = {**pages[page_key], "state": "in_flight"}
+                self._write_indexes(manifest, pages, partial=False)
+
+                try:
+                    response = self._provider_for(manifest).send(request)
+                except Exception as exc:
+                    self._fail_attempt(manifest, pages, page_number, attempt, state="failed_retryable", diagnostic=str(exc))
+                    return _PageOutcome("transport_error")
+
+                parsed = get_builtin_profile(manifest.profile).parse_and_validate(response.markdown)
+                if not parsed.ok:
+                    state = "failed_terminal" if parsed.retry_classification == "terminal" else "failed_retryable"
+                    self._fail_attempt(manifest, pages, page_number, attempt, state=state, diagnostic=parsed.diagnostic)
+                    return _PageOutcome("content_failure")
+                finding = self.verifier.classify(parsed.markdown)
+                if not finding.accepted:
+                    state = "failed_terminal" if finding.retry_class == "terminal" else "failed_retryable"
+                    self._fail_attempt(manifest, pages, page_number, attempt, state=state, diagnostic=finding.kind)
+                    return _PageOutcome("content_failure")
+
+                artifact_rel = self._artifact_rel(manifest.job_id, page_number)
+                artifact = {
+                    "schema_version": CURRENT_SCHEMA_VERSION,
+                    "kind": "page_artifact",
+                    "document_id": manifest.document_id,
+                    "page_number": page_number,
+                    "page_id": request.page_id,
+                    "markdown": parsed.markdown,
+                    "result_pointer": str(artifact_rel),
+                    "verifier_metadata": [finding.__dict__ if hasattr(finding, "__dict__") else {
+                        "accepted": finding.accepted,
+                        "kind": finding.kind,
+                        "retry_class": finding.retry_class,
+                        "warnings": list(finding.warnings),
+                    }],
+                    "fingerprint": request.fingerprint,
+                    "image_hash": request.image_hash,
+                    "provider_request_id": response.provider_request_id,
+                    "provider_metadata": response.metadata,
+                    "profile_metadata": parsed.metadata,
+                }
+                with self.governor.acquire(ResourceKind.STATE_STORE):
+                    self.state.write_json_atomic(artifact_rel, artifact)
+                committed = {
+                    **attempt,
+                    "state": "succeeded",
+                    "provider_response_committed_at": float(self.clock()),
+                    "result_pointer": str(artifact_rel),
+                }
+                self._write_ledger(manifest.job_id, attempt_id, committed)
+                pages[page_key] = {
+                    **pages[page_key],
+                    "state": "succeeded",
+                    "artifact_path": str(artifact_rel),
+                    "fingerprint": request.fingerprint,
+                }
+                self._write_indexes(manifest, pages, partial=False)
+                return _PageOutcome("succeeded")
+```
+
+- [ ] **Step 5: Run the ordering test + full suite**
+
+Run: `poetry run pytest tests/test_runner_scheduling.py::GovernedOrderingTests -q && poetry run pytest -q`
+Expected: PASS. Note: if `ResourceOrderViolation` is raised, the nesting order is wrong — provider (5) MUST be acquired before page_lease (6), and render (3) released before provider acquired. The structure above satisfies this.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/paperscale/runner.py tests/test_runner_scheduling.py
+git commit -m "feat(runner): govern render/provider/state acquisition order per page"
+```
+
+---
+
+## Task 4: Retry transient provider errors with backoff
+
+**Files:**
+- Modify: `src/paperscale/runner.py` (already loop-capable from Task 3 — this task only adds the test that proves it)
+- Test: `tests/test_runner_scheduling.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_runner_scheduling.py`:
+
+```python
+class RetryBackoffTests(unittest.TestCase):
+    def test_transient_provider_errors_are_retried_with_backoff_then_succeed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            sleeps: list[float] = []
+            provider = _ScriptedProvider(fail_first=2)
+            runner = _runner(state_root, provider, sleeper=sleeps.append, capacity="local-vllm-small")
+            status = runner.run(input_path=state_root / "in.pdf", output_path=state_root / "out.md", job_id="job")
+            self.assertEqual(status.succeeded, 1)
+            self.assertEqual(provider.calls, 3)          # 2 failures + 1 success
+            self.assertEqual(sleeps, [1.0, 2.0])         # exponential backoff from local-vllm-small (initial 1.0)
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `poetry run pytest tests/test_runner_scheduling.py::RetryBackoffTests -q`
+Expected: This should already PASS if Task 3 is complete (the retry loop + sleeper are in place). If it FAILS, that means Task 3's loop is wrong — fix the loop in `_process_pages`, not the test.
+
+> Note on TDD ordering: the retry loop lives in `_process_pages` (Task 3) because the governed `with` blocks make a standalone minimal implementation impractical. This test is the behavioral proof for the retry path; treat a failure here as a Task 3 regression.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `poetry run pytest -q`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_runner_scheduling.py
+git commit -m "test(runner): transient provider errors retried with exponential backoff"
+```
+
+---
+
+## Task 5: Circuit breaker stops the run and leaves remaining pages pending
+
+**Files:**
+- Modify: `src/paperscale/runner.py` (behavior already present from Task 3 — verify via test)
+- Test: `tests/test_runner_scheduling.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_runner_scheduling.py` (uses a 2-page renderer, so override the factory inline):
+
+```python
+class CircuitBreakerTests(unittest.TestCase):
+    def test_circuit_opens_after_threshold_and_leaves_remaining_pages_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            sleeps: list[float] = []
+            provider = _ScriptedProvider(always_fail=True)
+            runner = DocumentOcrRunner(
+                RunnerConfig(state_root=state_root, base_url="http://fake/v1", model="mock-vlm", capacity="local-vllm-small"),
+                provider=provider,
+                renderer_factory=lambda _path, _options: _FakeRenderer([b"page-1", b"page-2"]),
+                sleeper=sleeps.append,
+            )
+            status = runner.run(
+                input_path=state_root / "in.pdf",
+                output_path=state_root / "out.md",
+                job_id="job",
+                allow_partial=True,
+            )
+            # local-vllm-small threshold is 3: 3 failed attempts on page 1 open the circuit.
+            self.assertEqual(provider.calls, 3)
+            self.assertEqual(status.succeeded, 0)
+            self.assertEqual(status.failed_retryable, 1)   # page 1 left failed_retryable
+            self.assertEqual(status.pending, 1)            # page 2 never started
+            self.assertEqual(len(sleeps), 2)               # 2 backoffs before the 3rd failure trips the breaker
+```
+
+- [ ] **Step 2: Run it to verify it fails or passes**
+
+Run: `poetry run pytest tests/test_runner_scheduling.py::CircuitBreakerTests -q`
+Expected: PASS if Task 3's `if overload.circuit_open: break` and the retry loop are correct. If `status.pending` is 0 (page 2 was attempted) or `provider.calls != 3`, the circuit-break guard at the top of the page loop is missing/misplaced — fix `_process_pages`.
+
+- [ ] **Step 3: Run the full suite + lint**
+
+Run: `poetry run pytest -q && poetry run ruff check src/paperscale/runner.py src/paperscale/providers/self_hosted.py tests/test_runner_scheduling.py`
+Expected: PASS, `All checks passed!`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_runner_scheduling.py
+git commit -m "test(runner): circuit breaker halts run and preserves pending pages"
+```
+
+---
+
+## Task 6: Document capacity/circuit behavior
+
+**Files:**
+- Modify: `docs/ledger-recovery.md`
+
+- [ ] **Step 1: Append an "Operator behavior" note**
+
+Add a subsection to `docs/ledger-recovery.md` documenting: the real runner processes pages sequentially under `ResourceGovernor` ordering (`scheduler → render → provider → page_lease → state_store`); transient provider errors are retried with exponential backoff bounded by the job's capacity profile (`builtin_capacity_profile(manifest.capacity)`); after `circuit_breaker_failure_threshold` consecutive failures the circuit opens, the run stops, and remaining pages stay `pending` for a later `paperscale resume`. Keep it to ~8 lines, matching the file's existing terse style.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/ledger-recovery.md
+git commit -m "docs: describe real-runner capacity gating and circuit-breaker behavior"
+```
+
+---
+
+## Self-Review Notes (for the implementer)
+
+- **Acquisition order is load-bearing.** The governor raises on any out-of-order acquire. The only valid nesting is `SCHEDULER(2) → RENDER(3)`(release) `→ PROVIDER(5) → PAGE_LEASE(6) → STATE_STORE(7)`(per write). Never acquire a lower-numbered resource while holding a higher one.
+- **`file_descriptor(4)` is deliberately not modeled** for internal atomic writes; the store encapsulates its own fds. Governing at `state_store_lock(7)` is the documented granularity. Do not route `FileSystemStateStore` opens through `governor.open_file` in this plan — that's a separate, larger change.
+- **The circuit threshold is the retry budget.** There is no separate `max_attempts`; `record_failure` stops retrying once `circuit_open` (consecutive failures ≥ `circuit_breaker_failure_threshold`). This is bounded and cannot infinite-loop.
+- **Content failures (parse/verify) are not retried in-run** — `_process_page` returns `"content_failure"` and the loop breaks, matching pre-existing behavior. Only `"transport_error"` drives the overload controller.
+- **Type consistency:** `_PageOutcome.status` is one of exactly `"succeeded"`, `"transport_error"`, `"content_failure"`; `record_failure(*, retryable: bool) -> BackoffDecision`; `_capacity_for(manifest) -> ProviderCapacityProfile`.
+- **Regression proof:** Tasks 2, 3, 5 each run the full suite. The happy-path integration tests passing under the real `ResourceGovernor` is the proof that ordering is correct.

--- a/poetry.lock
+++ b/poetry.lock
@@ -377,6 +377,18 @@ files = [
 all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
+
+[[package]]
 name = "jiter"
 version = "0.15.0"
 description = "Fast iterable JSON parser."
@@ -524,6 +536,18 @@ realtime = ["websockets (>=13,<16)"]
 voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+description = "Core utilities for Python packages"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
+    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
+]
+
+[[package]]
 name = "pdf-oxide"
 version = "0.3.61"
 description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
@@ -544,6 +568,22 @@ files = [
 
 [package.extras]
 ocr = ["onnxruntime (>=1.20.1)"]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pydantic"
@@ -701,6 +741,21 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pyrefly"
 version = "1.0.0"
 description = "A fast type checker and language server for Python with powerful IDE features"
@@ -719,6 +774,28 @@ files = [
     {file = "pyrefly-1.0.0-py3-none-win_arm64.whl", hash = "sha256:d150fa9e40e8392832be81c3bcfc0497c146674ce4d0f8e04e1ec29e775ffb8c"},
     {file = "pyrefly-1.0.0.tar.gz", hash = "sha256:5c2b810ffcebd84be71de5df1223651edee951653a66935c6f091e957c452455"},
 ]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
+    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dotenv"
@@ -1219,5 +1296,5 @@ mock-api = ["fastapi", "uvicorn"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">3.12"
-content-hash = "70cb0b7f808b572a185cdf17d312f08aac9ff0390d3bd87f62e5dcf7f1e35ae2"
+python-versions = ">=3.12"
+content-hash = "464eaf9f899b4d4f35f83d979a7e536958cabf25ab9c58e7145834cbaa22df14"

--- a/poetry.lock
+++ b/poetry.lock
@@ -548,26 +548,129 @@ files = [
 ]
 
 [[package]]
-name = "pdf-oxide"
-version = "0.3.61"
-description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
+name = "pillow"
+version = "11.3.0"
+description = "Python Imaging Library (Fork)"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pdf_oxide-0.3.61-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2be7b1b090de568ddc3920694a139fd55429ec44f872d674142467083cc0da04"},
-    {file = "pdf_oxide-0.3.61-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f686ce976526b7241b2e5dd1d38d140b098621dc24a04d88610f5f650bde471f"},
-    {file = "pdf_oxide-0.3.61-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:768c1550ac5a39ff09149ed8efcee97d5a7748210d2f627a11b54c6c349fd3f9"},
-    {file = "pdf_oxide-0.3.61-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4282a80d2ae28d4666963074433bf36f3e24253aa6bf9bb53252d8044e5a7214"},
-    {file = "pdf_oxide-0.3.61-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1983b3757d23a4cabd570fc52a0d692a2b62fa85e09726b0a5aa61f975a49091"},
-    {file = "pdf_oxide-0.3.61-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9f25b2550513671ff203119cbdce6fcb6c3c73b9a3f37b178e1476648643a6fa"},
-    {file = "pdf_oxide-0.3.61-cp38-abi3-win_amd64.whl", hash = "sha256:d2e0c4cf67d2f3f7fae72d06615e9d77163f1219ff3ba3058945dff159a2e5d0"},
-    {file = "pdf_oxide-0.3.61-cp38-abi3-win_arm64.whl", hash = "sha256:9dc728889d8bd1d27337d4a2d6b697bd9ad4a8339ebed6c8a309029d5aef6afa"},
-    {file = "pdf_oxide-0.3.61.tar.gz", hash = "sha256:826b0934463247cc8514fb187db7bbacf05981233824bacb85137ac207aba059"},
+    {file = "pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"},
+    {file = "pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae"},
+    {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9"},
+    {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:040a5b691b0713e1f6cbe222e0f4f74cd233421e105850ae3b3c0ceda520f42e"},
+    {file = "pillow-11.3.0-cp310-cp310-win32.whl", hash = "sha256:89bd777bc6624fe4115e9fac3352c79ed60f3bb18651420635f26e643e3dd1f6"},
+    {file = "pillow-11.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:19d2ff547c75b8e3ff46f4d9ef969a06c30ab2d4263a9e287733aa8b2429ce8f"},
+    {file = "pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f"},
+    {file = "pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722"},
+    {file = "pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f"},
+    {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e"},
+    {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:932c754c2d51ad2b2271fd01c3d121daaa35e27efae2a616f77bf164bc0b3e94"},
+    {file = "pillow-11.3.0-cp311-cp311-win32.whl", hash = "sha256:b4b8f3efc8d530a1544e5962bd6b403d5f7fe8b9e08227c6b255f98ad82b4ba0"},
+    {file = "pillow-11.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a992e86b0dd7aeb1f053cd506508c0999d710a8f07b4c791c63843fc6a807ac"},
+    {file = "pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd"},
+    {file = "pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4"},
+    {file = "pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024"},
+    {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809"},
+    {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d"},
+    {file = "pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149"},
+    {file = "pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d"},
+    {file = "pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f"},
+    {file = "pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c"},
+    {file = "pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8"},
+    {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2"},
+    {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b"},
+    {file = "pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3"},
+    {file = "pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51"},
+    {file = "pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580"},
+    {file = "pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e"},
+    {file = "pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59"},
+    {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe"},
+    {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c"},
+    {file = "pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788"},
+    {file = "pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31"},
+    {file = "pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e"},
+    {file = "pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12"},
+    {file = "pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77"},
+    {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874"},
+    {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a"},
+    {file = "pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214"},
+    {file = "pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635"},
+    {file = "pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6"},
+    {file = "pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae"},
+    {file = "pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477"},
+    {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50"},
+    {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b"},
+    {file = "pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12"},
+    {file = "pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db"},
+    {file = "pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa"},
+    {file = "pillow-11.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:48d254f8a4c776de343051023eb61ffe818299eeac478da55227d96e241de53f"},
+    {file = "pillow-11.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7aee118e30a4cf54fdd873bd3a29de51e29105ab11f9aad8c32123f58c8f8081"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:23cff760a9049c502721bdb743a7cb3e03365fafcdfc2ef9784610714166e5a4"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6359a3bc43f57d5b375d1ad54a0074318a0844d11b76abccf478c37c986d3cfc"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:092c80c76635f5ecb10f3f83d76716165c96f5229addbd1ec2bdbbda7d496e06"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cadc9e0ea0a2431124cde7e1697106471fc4c1da01530e679b2391c37d3fbb3a"},
+    {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6a418691000f2a418c9135a7cf0d797c1bb7d9a485e61fe8e7722845b95ef978"},
+    {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:97afb3a00b65cc0804d1c7abddbf090a81eaac02768af58cbdcaaa0a931e0b6d"},
+    {file = "pillow-11.3.0-cp39-cp39-win32.whl", hash = "sha256:ea944117a7974ae78059fcc1800e5d3295172bb97035c0c1d9345fca1419da71"},
+    {file = "pillow-11.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:e5c5858ad8ec655450a7c7df532e9842cf8df7cc349df7225c60d5d348c8aada"},
+    {file = "pillow-11.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:6abdbfd3aea42be05702a8dd98832329c167ee84400a1d1f61ab11437f1717eb"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8"},
+    {file = "pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523"},
 ]
 
 [package.extras]
-ocr = ["onnxruntime (>=1.20.1)"]
+docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+test-arrow = ["pyarrow"]
+tests = ["check-manifest", "coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "trove-classifiers (>=2024.10.12)"]
+typing = ["typing-extensions ; python_version < \"3.10\""]
+xmp = ["defusedxml"]
 
 [[package]]
 name = "pluggy"
@@ -754,6 +857,29 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pypdfium2"
+version = "4.30.0"
+description = "Python bindings to PDFium"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "pypdfium2-4.30.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:b33ceded0b6ff5b2b93bc1fe0ad4b71aa6b7e7bd5875f1ca0cdfb6ba6ac01aab"},
+    {file = "pypdfium2-4.30.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4e55689f4b06e2d2406203e771f78789bd4f190731b5d57383d05cf611d829de"},
+    {file = "pypdfium2-4.30.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e6e50f5ce7f65a40a33d7c9edc39f23140c57e37144c2d6d9e9262a2a854854"},
+    {file = "pypdfium2-4.30.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3d0dd3ecaffd0b6dbda3da663220e705cb563918249bda26058c6036752ba3a2"},
+    {file = "pypdfium2-4.30.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc3bf29b0db8c76cdfaac1ec1cde8edf211a7de7390fbf8934ad2aa9b4d6dfad"},
+    {file = "pypdfium2-4.30.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1f78d2189e0ddf9ac2b7a9b9bd4f0c66f54d1389ff6c17e9fd9dc034d06eb3f"},
+    {file = "pypdfium2-4.30.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5eda3641a2da7a7a0b2f4dbd71d706401a656fea521b6b6faa0675b15d31a163"},
+    {file = "pypdfium2-4.30.0-py3-none-musllinux_1_1_i686.whl", hash = "sha256:0dfa61421b5eb68e1188b0b2231e7ba35735aef2d867d86e48ee6cab6975195e"},
+    {file = "pypdfium2-4.30.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:f33bd79e7a09d5f7acca3b0b69ff6c8a488869a7fab48fdf400fec6e20b9c8be"},
+    {file = "pypdfium2-4.30.0-py3-none-win32.whl", hash = "sha256:ee2410f15d576d976c2ab2558c93d392a25fb9f6635e8dd0a8a3a5241b275e0e"},
+    {file = "pypdfium2-4.30.0-py3-none-win_amd64.whl", hash = "sha256:90dbb2ac07be53219f56be09961eb95cf2473f834d01a42d901d13ccfad64b4c"},
+    {file = "pypdfium2-4.30.0-py3-none-win_arm64.whl", hash = "sha256:119b2969a6d6b1e8d55e99caaf05290294f2d0fe49c12a3f17102d01c441bd29"},
+    {file = "pypdfium2-4.30.0.tar.gz", hash = "sha256:48b5b7e5566665bc1015b9d69c1ebabe21f6aee468b509531c3c8318eeee2e16"},
+]
 
 [[package]]
 name = "pyrefly"
@@ -1297,4 +1423,4 @@ mock-api = ["fastapi", "uvicorn"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "464eaf9f899b4d4f35f83d979a7e536958cabf25ab9c58e7145834cbaa22df14"
+content-hash = "7497db82170ce33f10e54e466aa74eff4941e40304d97413cc20a5b759a140d1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "openai (>=2.37.0,<3.0.0)",
-    "pdf-oxide (>=0.3.49,<0.4.0)"
+    "httpx (>=0.28.1,<0.29.0)",
+    "pypdfium2 (>=4.30.0,<5.0.0)",
+    "pillow (>=10.0.0,<12.0.0)"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "charitarthchugh",email = "37895518+charitarthchugh@users.noreply.github.com"}
 ]
 license = "MIT"
-requires-python = ">3.12"
+requires-python = ">=3.12"
 dependencies = [
     "openai (>=2.37.0,<3.0.0)",
     "pdf-oxide (>=0.3.49,<0.4.0)"
@@ -23,6 +23,7 @@ packages = [{ include = "paperscale", from = "src" }]
 
 [dependency-groups]
 dev = [
+    "pytest (>=8.0.0,<9.0.0)",
     "pyrefly (>=1.0.0,<2.0.0)",
     "ruff (>=0.15.13,<0.16.0)",
     "fastapi (>=0.136.3,<0.137.0)",

--- a/scripts/loadtest.py
+++ b/scripts/loadtest.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+"""Load-test paperscale against a real vLLM server using the multi-process work queue.
+
+Pre-enqueues N PDFs as jobs, then launches P concurrent ``paperscale work`` processes
+(each claiming jobs via the O_EXCL ClaimStore and running pages through the asyncio
+pool). Reports throughput (pages/sec) and per-page provider latency percentiles read
+from the per-attempt ledger (the durable truth).
+
+Usage:
+  poetry run python scripts/loadtest.py \
+      --pdf-dir /run/media/cc/data/law/pdfs --count 12 --processes 3 \
+      --base-url http://127.0.0.1:8000 --model deepseek-ai/DeepSeek-OCR-2 \
+      --profile deepseek_ocr_2 --max-in-flight 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _find_pdfs(pdf_dir: Path, count: int) -> list[Path]:
+    # Over-collect so we can skip unreadable/corrupt PDFs and still hit `count`.
+    found: list[Path] = []
+    for path in pdf_dir.rglob("*.pdf"):
+        found.append(path)
+        if len(found) >= count * 4:
+            break
+    return found
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, int(round((pct / 100.0) * (len(ordered) - 1))))
+    return ordered[index]
+
+
+def _collect_metrics(state_root: Path) -> dict[str, object]:
+    succeeded = 0
+    terminal = 0
+    pages_total = 0
+    latencies: list[float] = []
+    jobs_dir = state_root / "jobs"
+    for job_dir in jobs_dir.iterdir() if jobs_dir.exists() else []:
+        status_path = job_dir / "indexes" / "status.json"
+        if status_path.exists():
+            status = json.loads(status_path.read_text())
+            succeeded += int(status.get("succeeded", 0))
+            terminal += int(status.get("failed_terminal", 0))
+            pages_total += int(status.get("pages_total", 0))
+        ledger_dir = job_dir / "ledger"
+        if ledger_dir.exists():
+            for rec_path in ledger_dir.glob("*.json"):
+                rec = json.loads(rec_path.read_text())
+                started = rec.get("provider_started_at")
+                committed = rec.get("provider_response_committed_at")
+                if isinstance(started, (int, float)) and isinstance(committed, (int, float)):
+                    latencies.append(float(committed) - float(started))
+    return {
+        "succeeded": succeeded,
+        "failed_terminal": terminal,
+        "pages_total": pages_total,
+        "provider_calls_committed": len(latencies),
+        "latency_p50_s": round(_percentile(latencies, 50), 3),
+        "latency_p95_s": round(_percentile(latencies, 95), 3),
+        "latency_max_s": round(max(latencies), 3) if latencies else 0.0,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pdf-dir", required=True, type=Path)
+    parser.add_argument("--count", type=int, default=12)
+    parser.add_argument("--processes", type=int, default=3)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model", default="deepseek-ai/DeepSeek-OCR-2")
+    parser.add_argument("--profile", default="deepseek_ocr_2")
+    parser.add_argument("--max-in-flight", type=int, default=8)
+    parser.add_argument("--max-attempts", type=int, default=3)
+    parser.add_argument("--server-max-num-seqs", type=int, default=32)
+    parser.add_argument("--state-root", type=Path, default=Path("/tmp/ps-loadtest/.paperscale"))
+    parser.add_argument("--keep-state", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.keep_state and args.state_root.exists():
+        shutil.rmtree(args.state_root)
+    args.state_root.mkdir(parents=True, exist_ok=True)
+    out_dir = args.state_root.parent / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pdfs = _find_pdfs(args.pdf_dir, args.count)
+    if not pdfs:
+        print(f"no PDFs found under {args.pdf_dir}", file=sys.stderr)
+        return 1
+
+    # Enqueue jobs in-process (front door for the work queue).
+    from paperscale.runner import DocumentOcrRunner, RunnerConfig
+
+    enqueuer = DocumentOcrRunner(
+        RunnerConfig(
+            state_root=args.state_root, base_url=args.base_url, model=args.model,
+            profile=args.profile, server_max_num_seqs=args.server_max_num_seqs,
+        )
+    )
+    enqueued = 0
+    for pdf in pdfs:
+        if enqueued >= args.count:
+            break
+        try:
+            enqueuer.enqueue(input_path=pdf, output_path=out_dir / f"job-{enqueued}.md", job_id=f"job-{enqueued}")
+            enqueued += 1
+        except Exception as exc:  # noqa: BLE001 - skip corrupt/unreadable PDFs
+            print(f"skip {pdf.name}: {exc}")
+    print(f"enqueued {enqueued} jobs; launching {args.processes} work processes...")
+
+    # `work` reads base_url/model/profile from each job's manifest, so it only needs
+    # the state root, worker identity, and the concurrency knobs.
+    cmd = [
+        sys.executable, "-m", "paperscale.cli", "work",
+        "--state-root", str(args.state_root),
+        "--server-max-num-seqs", str(args.server_max_num_seqs),
+        "--max-in-flight-requests", str(args.max_in_flight),
+        "--max-attempts", str(args.max_attempts),
+    ]
+    start = time.monotonic()
+    procs = [
+        subprocess.Popen([*cmd, "--worker-id", f"w{i}"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        for i in range(args.processes)
+    ]
+    for proc in procs:
+        out, _ = proc.communicate()
+        sys.stdout.write(out or "")
+    wall = time.monotonic() - start
+
+    metrics = _collect_metrics(args.state_root)
+    pages_per_sec = round(int(metrics["succeeded"]) / wall, 2) if wall > 0 else 0.0
+    print("\n==== load test results ====")
+    print(json.dumps({**metrics, "wall_seconds": round(wall, 2), "pages_per_sec": pages_per_sec,
+                      "processes": args.processes, "max_in_flight": args.max_in_flight}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/paperscale/async_pool.py
+++ b/src/paperscale/async_pool.py
@@ -1,0 +1,63 @@
+"""Async concurrency primitives for the full-lifecycle worker pool.
+
+``AdaptiveLimiter`` is a resizable concurrency gate. A plain ``asyncio.Semaphore``
+cannot change its bound at runtime, but AIMD needs exactly that: additive-increase
+on sustained success up to a ceiling, multiplicative-decrease toward a floor on
+overload. The limiter caps concurrent holders at a *mutable* ``limit`` in
+``[1, maximum]`` and wakes waiters when the limit grows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+
+class AdaptiveLimiter:
+    def __init__(self, limit: int, *, maximum: int) -> None:
+        self._maximum = max(1, maximum)
+        self._limit = max(1, min(limit, self._maximum))
+        self._in_use = 0
+        self._cond = asyncio.Condition()
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    @property
+    def in_use(self) -> int:
+        return self._in_use
+
+    @property
+    def maximum(self) -> int:
+        return self._maximum
+
+    async def set_limit(self, value: int) -> None:
+        async with self._cond:
+            new_limit = max(1, min(int(value), self._maximum))
+            grew = new_limit > self._limit
+            self._limit = new_limit
+            if grew:
+                # Wake enough waiters to fill the newly available slots.
+                self._cond.notify_all()
+
+    async def acquire(self) -> None:
+        async with self._cond:
+            while self._in_use >= self._limit:
+                await self._cond.wait()
+            self._in_use += 1
+
+    async def release(self) -> None:
+        async with self._cond:
+            if self._in_use > 0:
+                self._in_use -= 1
+            self._cond.notify(1)
+
+    @asynccontextmanager
+    async def slot(self) -> AsyncIterator[None]:
+        await self.acquire()
+        try:
+            yield
+        finally:
+            await self.release()

--- a/src/paperscale/cli.py
+++ b/src/paperscale/cli.py
@@ -46,6 +46,12 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--allow-partial", action="store_true", help="assemble succeeded pages even if some pages fail")
     run_parser.set_defaults(handler=_handle_run)
 
+    enqueue_parser = subparsers.add_parser("enqueue", help="register a job for later `work` processing (does not run it)")
+    _add_runner_options(enqueue_parser, include_job_id=True)
+    enqueue_parser.add_argument("--input", required=True, type=Path, help="PDF input path")
+    enqueue_parser.add_argument("--output", required=True, type=Path, help="Markdown output path")
+    enqueue_parser.set_defaults(handler=_handle_enqueue)
+
     status_parser = subparsers.add_parser("status", help="show compact-index workload status")
     _add_state_job_options(status_parser)
     status_parser.add_argument("--json", action="store_true", help="emit JSON")
@@ -53,9 +59,19 @@ def build_parser() -> argparse.ArgumentParser:
 
     resume_parser = subparsers.add_parser("resume", help="resume pending work using compact indexes")
     _add_state_job_options(resume_parser)
+    _add_recovery_concurrency_options(resume_parser)
     resume_parser.add_argument("--retry-ambiguous", action="store_true", help="retry ambiguous in-flight attempts")
     resume_parser.add_argument("--allow-partial", action="store_true", help="assemble succeeded pages even if some pages fail")
     resume_parser.set_defaults(handler=_handle_resume)
+
+    work_parser = subparsers.add_parser(
+        "work", help="claim and run available incomplete jobs (single machine, multi-process)"
+    )
+    work_parser.add_argument("--state-root", default=Path(".paperscale"), type=Path, help="state root directory")
+    work_parser.add_argument("--worker-id", default="local", help="worker identity stamped on claims/attempts")
+    work_parser.add_argument("--max-jobs", type=int, default=None, help="stop after claiming this many jobs")
+    _add_recovery_concurrency_options(work_parser)
+    work_parser.set_defaults(handler=_handle_work)
 
     reconcile_parser = subparsers.add_parser("reconcile", help="surface ambiguous attempts and duplicate-call risk")
     _add_state_job_options(reconcile_parser)
@@ -101,6 +117,23 @@ def _add_runner_options(parser: argparse.ArgumentParser, *, include_job_id: bool
     parser.add_argument("--base-url", required=True, help="OpenAI-compatible base URL; /v1 is appended when omitted")
     parser.add_argument("--model", help="served model id")
     parser.add_argument("--capacity", default="local-vllm-small", help="capacity profile")
+    _add_recovery_concurrency_options(parser)
+
+
+def _add_recovery_concurrency_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--metered",
+        action="store_true",
+        help="treat the provider as billable/non-idempotent: escalate crashed in-flight pages to ambiguous (not auto-requeue). NOT persisted; pass it on every invocation.",
+    )
+    parser.add_argument("--max-attempts", type=int, default=8, help="hard per-page retry cap before terminal demotion")
+    parser.add_argument(
+        "--server-max-num-seqs", type=int, default=128,
+        help="server's --max-num-seqs; max_in_flight defaults to 4x this",
+    )
+    parser.add_argument("--max-in-flight-requests", type=int, default=None, help="process-wide cap on requests sent to the server")
+    parser.add_argument("--max-open-documents", type=int, default=128, help="cap on concurrently open PDF handles")
+    parser.add_argument("--render-ahead", type=int, default=None, help="bounded decoded-image prefetch (pages)")
 
 
 def _add_state_job_options(parser: argparse.ArgumentParser) -> None:
@@ -137,15 +170,58 @@ def _runner_from_args(args: argparse.Namespace):
             base_url=getattr(args, "base_url", ""),
             model=getattr(args, "model", None),
             capacity=getattr(args, "capacity", "local-vllm-small"),
+            worker_id=getattr(args, "worker_id", "local"),
+            metered=bool(getattr(args, "metered", False)),
+            max_attempts=int(getattr(args, "max_attempts", 8)),
+            server_max_num_seqs=int(getattr(args, "server_max_num_seqs", 128)),
+            max_in_flight_requests=getattr(args, "max_in_flight_requests", None),
+            max_open_documents=int(getattr(args, "max_open_documents", 128)),
+            render_ahead=getattr(args, "render_ahead", None),
         )
     )
+
+
+def _print_run_status(status) -> int:
+    """Print a status line and pick the exit code, distinguishing settled-with-failures."""
+    print(f"job {status.job_id}: succeeded={status.succeeded}/{status.pages_total} output={status.output_path}")
+    if status.complete:
+        return 0
+    if status.settled and status.has_terminal_failures:
+        # Reporting-only: resume cannot progress. Make the message actionable.
+        print(
+            f"job {status.job_id}: settled with {status.failed_terminal} terminal failure(s); "
+            f"resume will not progress — pass --allow-partial to assemble "
+            f"{status.succeeded}/{status.pages_total}, or re-source the failed page(s)."
+        )
+        return 2
+    if status.succeeded > 0 and status.partial:
+        return 0
+    return 1
 
 
 def _handle_run(args: argparse.Namespace) -> int:
     runner = _runner_from_args(args)
     status = runner.run(input_path=args.input, output_path=args.output, job_id=args.job_id, allow_partial=args.allow_partial)
-    print(f"job {status.job_id}: succeeded={status.succeeded}/{status.pages_total} output={status.output_path}")
-    return 0 if status.complete or (args.allow_partial and status.succeeded > 0) else 1
+    return _print_run_status(status)
+
+
+def _handle_enqueue(args: argparse.Namespace) -> int:
+    runner = _runner_from_args(args)
+    job_id = runner.enqueue(input_path=args.input, output_path=args.output, job_id=args.job_id)
+    print(f"enqueued job {job_id}")
+    return 0
+
+
+def _handle_work(args: argparse.Namespace) -> int:
+    runner = _runner_from_args(args)
+    statuses = runner.work(max_jobs=getattr(args, "max_jobs", None))
+    if not statuses:
+        print("no claimable jobs")
+        return 0
+    for status in statuses:
+        state = "complete" if status.complete else ("settled" if status.settled else "in-progress")
+        print(f"job {status.job_id}: {state} succeeded={status.succeeded}/{status.pages_total}")
+    return 0 if all(s.complete for s in statuses) else 1
 
 
 def _handle_status(args: argparse.Namespace) -> int:
@@ -162,8 +238,7 @@ def _handle_status(args: argparse.Namespace) -> int:
 def _handle_resume(args: argparse.Namespace) -> int:
     runner = _runner_from_args(args)
     status = runner.resume(args.job_id, retry_ambiguous=args.retry_ambiguous, allow_partial=args.allow_partial)
-    print(f"job {status.job_id}: succeeded={status.succeeded}/{status.pages_total} output={status.output_path}")
-    return 0 if status.complete or (args.allow_partial and status.succeeded > 0) else 1
+    return _print_run_status(status)
 
 
 def _handle_reconcile(args: argparse.Namespace) -> int:

--- a/src/paperscale/cli.py
+++ b/src/paperscale/cli.py
@@ -60,6 +60,13 @@ def build_parser() -> argparse.ArgumentParser:
     reconcile_parser = subparsers.add_parser("reconcile", help="surface ambiguous attempts and duplicate-call risk")
     _add_state_job_options(reconcile_parser)
     reconcile_parser.add_argument("--json", action="store_true", help="emit JSON")
+    resolve_group = reconcile_parser.add_mutually_exclusive_group()
+    resolve_group.add_argument(
+        "--supersede", type=int, metavar="PAGE", help="mark the ambiguous attempt superseded and requeue the page as pending"
+    )
+    resolve_group.add_argument(
+        "--accept", type=int, metavar="PAGE", help="accept the page's existing artifact and mark it succeeded"
+    )
     reconcile_parser.set_defaults(handler=_handle_reconcile)
 
     fsck_parser = subparsers.add_parser("fsck", help="scan-only filesystem consistency check")
@@ -162,7 +169,16 @@ def _handle_resume(args: argparse.Namespace) -> int:
 def _handle_reconcile(args: argparse.Namespace) -> int:
     from paperscale.runner import DocumentOcrRunner, RunnerConfig
 
-    payload = DocumentOcrRunner(RunnerConfig(state_root=args.state_root)).reconcile(args.job_id)
+    runner = DocumentOcrRunner(RunnerConfig(state_root=args.state_root))
+    if args.supersede is not None:
+        status = runner.resolve_ambiguous(args.job_id, args.supersede, action="supersede")
+        print(f"job {status.job_id}: page {args.supersede} superseded; succeeded={status.succeeded}/{status.pages_total} pending={status.pending}")
+        return 0
+    if args.accept is not None:
+        status = runner.resolve_ambiguous(args.job_id, args.accept, action="accept")
+        print(f"job {status.job_id}: page {args.accept} accepted; succeeded={status.succeeded}/{status.pages_total}")
+        return 0
+    payload = runner.reconcile(args.job_id)
     if args.json:
         print(json.dumps(payload, sort_keys=True))
     else:
@@ -284,5 +300,7 @@ def format_ambiguous_attempts(*, count: int, page_sample: list[str]) -> str:
     return (
         f"{count} ambiguous OCR attempts require operator reconciliation. "
         f"Sample pages: {sample}. Retrying can create duplicate provider calls; "
-        "use --retry-ambiguous only after accepting that risk or confirming idempotency."
+        "use --retry-ambiguous only after accepting that risk or confirming idempotency. "
+        "Per page, resolve with `reconcile --supersede PAGE` (discard the uncertain attempt and requeue) "
+        "or `reconcile --accept PAGE` (keep the page's already-written artifact)."
     )

--- a/src/paperscale/profiles/base.py
+++ b/src/paperscale/profiles/base.py
@@ -33,6 +33,14 @@ class ModelOcrProfile:
     task: str = "document_to_markdown"
     public_modes: tuple[str, ...] = ("document_to_markdown",)
     provider: str = "openai-compatible-chat"
+    # Per-dimension remediation ceilings (monotonic escalation cannot exceed these).
+    max_decode_tokens: int = 16384
+    max_render_longest_side: int = 2600
+    max_repetition_penalty: float = 1.5
+    # DPI is what the renderer actually honors; bump it alongside target_longest_side
+    # so a mojibake remediation produces a genuinely higher-resolution image.
+    base_render_dpi: int = 144
+    max_render_dpi: int = 400
 
     def __post_init__(self) -> None:
         if self.task != "document_to_markdown":
@@ -76,18 +84,20 @@ class ModelOcrProfile:
     def parse_and_validate(self, output: str) -> ProfileValidationResult:
         markdown = output.strip()
         if not markdown:
+            # Canonical diagnostic codes (shared with the verifier + remediation table)
+            # so diagnostic-driven remediation can react to parse-stage failures too.
             return ProfileValidationResult(
                 ok=False,
                 markdown="",
                 retry_classification="retryable",
-                diagnostic="empty provider output",
+                diagnostic="empty_output",
             )
         if _has_repeated_ngram(markdown):
             return ProfileValidationResult(
                 ok=False,
                 markdown=markdown,
                 retry_classification="retryable",
-                diagnostic="repeated n-gram detected",
+                diagnostic="repeated_ngram",
             )
         return ProfileValidationResult(ok=True, markdown=markdown)
 
@@ -132,6 +142,59 @@ class ModelOcrProfile:
             decoding=next_decoding,
             render_options=next_render,
         )
+
+
+    def remediation_for(
+        self, diagnostic: str, *, accumulated: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Map a failure diagnostic to accumulated decoding/render overrides.
+
+        Overrides layer additively onto ``accumulated`` (the effective overrides
+        from prior attempts) rather than rebuilding from base, so a token bump for
+        a later ``truncation`` does not discard an earlier ``mojibake`` DPI bump.
+        Each dimension is clamped to its ceiling; an unknown diagnostic is identity.
+        Returns a dict with optional ``decoding``/``render_options`` keys suitable
+        for :meth:`with_overrides`.
+        """
+
+        prior = copy.deepcopy(accumulated) if accumulated else {}
+        decoding = dict(prior.get("decoding") or {})
+        render = dict(prior.get("render_options") or {})
+
+        if diagnostic in _TOKEN_DIAGNOSTICS:
+            current = int(decoding.get("max_tokens", self.decoding.get("max_tokens", 4096)))
+            decoding["max_tokens"] = min(current * 2, self.max_decode_tokens)
+        elif diagnostic in _RENDER_DIAGNOSTICS:
+            current = int(
+                render.get("target_longest_side", self.render_options.get("target_longest_side", 1280))
+            )
+            bumped = max(current + 1, int(current * 1.25))
+            render["target_longest_side"] = min(bumped, self.max_render_longest_side)
+            current_dpi = int(render.get("dpi", self.render_options.get("dpi", self.base_render_dpi)))
+            render["dpi"] = min(max(current_dpi + 1, int(current_dpi * 1.25)), self.max_render_dpi)
+        elif diagnostic in _REPETITION_DIAGNOSTICS:
+            # Step by 0.15: empirically the first bump to ~1.15 already breaks the
+            # decode loops VLMs fall into on dense pages, so the ladder converges fast.
+            current = float(decoding.get("repetition_penalty", 1.0))
+            decoding["repetition_penalty"] = min(round(current + 0.15, 3), self.max_repetition_penalty)
+        # else: unknown diagnostic -> identity (carry accumulated forward unchanged)
+
+        result: dict[str, Any] = {}
+        if decoding:
+            result["decoding"] = decoding
+        if render:
+            result["render_options"] = render
+        return result
+
+
+# Diagnostic -> remediation dimension. Diagnostics come from
+# ``ProfileValidationResult.diagnostic`` and ``VerificationFinding.kind``.
+_TOKEN_DIAGNOSTICS = frozenset({"truncation_indicator", "length_anomaly"})
+# empty_output re-renders at higher DPI: an empty completion on a content-bearing
+# page is often a too-small/low-detail image, so escalate resolution on retry rather
+# than re-rolling the identical request.
+_RENDER_DIAGNOSTICS = frozenset({"mojibake", "control_characters", "empty_output"})
+_REPETITION_DIAGNOSTICS = frozenset({"repeated_ngram", "repeated_character"})
 
 
 class ModelOcrProfileProtocol(Protocol):

--- a/src/paperscale/profiles/builtin.py
+++ b/src/paperscale/profiles/builtin.py
@@ -90,11 +90,11 @@ _BUILTINS: dict[str, ModelOcrProfile] = {
         prompt_version="v1",
         parser_version="deepseek-markdown-parser-v1",
         output_format="structured_markdown",
-        prompt_template=(
-            "Convert document page {page_id} to Markdown using DeepSeek-OCR-2 "
-            "document parsing mode. Preserve document structure and avoid repeated "
-            "tokens. Return only Markdown; free OCR mode is not available."
-        ),
+        # DeepSeek-OCR-2 requires its native `<image>` placeholder + a short OCR
+        # instruction; a verbose instruction without it makes the model emit an empty
+        # completion on many pages. The plain "convert to markdown" form returns clean
+        # Markdown (the `<|grounding|>` variant adds bbox coordinate prefixes).
+        prompt_template="<image>\nConvert the document to markdown.",
         decoding={
             "temperature": 0.0,
             "top_p": 0.95,

--- a/src/paperscale/providers/async_openai_chat.py
+++ b/src/paperscale/providers/async_openai_chat.py
@@ -1,0 +1,134 @@
+"""Async OpenAI-compatible chat/completions provider for the asyncio worker pool.
+
+vLLM serves ``/v1/chat/completions`` synchronously (request/response); workers
+``await`` their own responses, so there is no server to poll. The HTTP connection
+pool MUST be sized to match ``max_in_flight_requests`` (see
+``concurrency-and-queuing.md``), which :func:`build_async_chat_provider` does via
+``httpx.Limits``.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from paperscale.providers.base import PageOcrRequest, PageOcrResponse, ProviderError
+
+# Decoding keys the OpenAI chat schema accepts directly; everything else (e.g.
+# vLLM's ``repetition_penalty``) is forwarded via ``extra_body``.
+_STANDARD_DECODING = frozenset(
+    {"temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty", "stop", "seed"}
+)
+
+
+class AsyncOpenAIChatProvider:
+    """OpenAI-compatible chat adapter behind provider-neutral requests (async)."""
+
+    name = "openai-compatible-chat"
+
+    def __init__(self, *, client: Any) -> None:
+        self._client = client
+
+    async def send(self, request: PageOcrRequest) -> PageOcrResponse:
+        image_url = _data_url(request.image_media_type, request.image_bytes)
+        standard, extra = _split_decoding(request.decoding)
+        payload: dict[str, Any] = {
+            "model": request.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": request.prompt},
+                        {"type": "image_url", "image_url": {"url": image_url}},
+                    ],
+                }
+            ],
+            **standard,
+        }
+        if extra:
+            payload["extra_body"] = extra
+        try:
+            response = await self._client.chat.completions.create(**payload)
+        except Exception as exc:  # noqa: BLE001 - mapped to provider-neutral error
+            raise ProviderError(f"OpenAI-compatible chat request failed: {exc}") from exc
+
+        markdown = _extract_chat_text(response)
+        return PageOcrResponse(
+            markdown=markdown,
+            provider_request_id=_response_id(response, request.fingerprint),
+            raw=response,
+            metadata={"provider": self.name, "model": request.model},
+        )
+
+
+def build_async_chat_provider(
+    base_url: str,
+    *,
+    max_connections: int,
+    api_key: str = "paperscale-local",
+    timeout: float = 120.0,
+) -> AsyncOpenAIChatProvider:
+    """Build an async provider whose HTTP pool matches the in-flight ceiling."""
+
+    import httpx
+    from openai import AsyncOpenAI
+
+    limits = httpx.Limits(
+        max_connections=max_connections,
+        max_keepalive_connections=max_connections,
+    )
+    http_client = httpx.AsyncClient(limits=limits, timeout=timeout)
+    client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
+    return AsyncOpenAIChatProvider(client=client)
+
+
+def _split_decoding(decoding: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    standard: dict[str, Any] = {}
+    extra: dict[str, Any] = {}
+    for key, value in decoding.items():
+        (standard if key in _STANDARD_DECODING else extra)[key] = value
+    return standard, extra
+
+
+def _data_url(media_type: str, image_bytes: bytes) -> str:
+    encoded = base64.b64encode(image_bytes).decode("ascii")
+    return f"data:{media_type};base64,{encoded}"
+
+
+def _extract_chat_text(response: object) -> str:
+    """Extract chat content as a string.
+
+    Returns the content even when it is the empty string, and maps a ``None``
+    completion to ``""`` so an empty completion is classified downstream as an
+    ``empty_output`` *content* failure (retryable, never throttling) rather than a
+    transport error that would wrongly trip the circuit breaker. Only a structurally
+    malformed response (no choices / no message) is a transport-level ``ProviderError``.
+    """
+    choices = getattr(response, "choices", None)
+    if choices is None and isinstance(response, dict):
+        choices = response.get("choices")
+    if not choices:
+        raise ProviderError("provider response had no choices")
+    choice = choices[0]
+    message = getattr(choice, "message", None)
+    if message is None and isinstance(choice, dict):
+        message = choice.get("message")
+    if message is None:
+        raise ProviderError("provider response had no message")
+    content = getattr(message, "content", None)
+    if content is None and isinstance(message, dict):
+        content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if content is None:
+        return ""  # empty completion -> empty_output content failure, not transport error
+    raise ProviderError("provider response chat content was not text")
+
+
+def _response_id(response: object, fallback: str) -> str:
+    rid = getattr(response, "id", None)
+    if isinstance(rid, str) and rid:
+        return rid
+    if isinstance(response, dict) and isinstance(response.get("id"), str):
+        return response["id"]
+    return fallback

--- a/src/paperscale/providers/self_hosted.py
+++ b/src/paperscale/providers/self_hosted.py
@@ -176,14 +176,58 @@ class BackoffDecision:
 class ProviderOverloadController:
     """Small deterministic retry/circuit helper for scheduler-visible provider pressure."""
 
-    def __init__(self, capacity: ProviderCapacityProfile) -> None:
+    def __init__(
+        self,
+        capacity: ProviderCapacityProfile,
+        *,
+        floor: int | None = None,
+        ceiling: int | None = None,
+        decrease_factor: float = 0.5,
+        additive_step: int = 1,
+        success_threshold: int = 3,
+    ) -> None:
         self.capacity = capacity
         self._consecutive_failures = 0
         self._queued_requests = 0
+        # AIMD adaptive concurrency: float between floor (~server max_num_seqs) and
+        # ceiling (~4x max_num_seqs == client max_in_flight). Start fed at ceiling;
+        # AIMD's job is snap-back on overload, not ramp-up.
+        self._ceiling = int(ceiling if ceiling is not None else capacity.max_in_flight_requests)
+        self._floor = int(floor if floor is not None else max(1, self._ceiling // 4))
+        self._floor = max(1, min(self._floor, self._ceiling))
+        self._decrease_factor = decrease_factor
+        self._additive_step = max(1, additive_step)
+        self._success_threshold = max(1, success_threshold)
+        self._concurrency = self._ceiling
+        self._consecutive_successes = 0
 
     @property
     def queued_requests(self) -> int:
         return self._queued_requests
+
+    @property
+    def concurrency_limit(self) -> int:
+        """Current AIMD-governed in-flight target; resizes the runner's semaphore."""
+        return self._concurrency
+
+    def _shrink(self) -> None:
+        self._concurrency = max(self._floor, int(self._concurrency * self._decrease_factor))
+        self._consecutive_successes = 0
+
+    def _grow_on_success(self) -> None:
+        self._consecutive_successes += 1
+        if self._consecutive_successes >= self._success_threshold:
+            self._consecutive_successes = 0
+            self._concurrency = min(self._ceiling, self._concurrency + self._additive_step)
+
+    def note_content_failure(self) -> None:
+        """Record a content/parse/verify rejection.
+
+        Signal hygiene: a content ``400`` or a mojibake/repetition rejection is NOT
+        an overload signal, so it must never shrink concurrency or trip the circuit
+        (else a mojibake-heavy run self-throttles against a healthy server).
+        """
+        return None
 
     @property
     def circuit_open(self) -> bool:
@@ -201,11 +245,13 @@ class ProviderOverloadController:
 
     def record_success(self) -> BackoffDecision:
         self._consecutive_failures = 0
+        self._grow_on_success()
         return BackoffDecision(False, 0.0, False, "success")
 
     def record_status(self, status_code: int) -> BackoffDecision:
         if status_code in (429, 500, 502, 503, 504):
             self._consecutive_failures += 1
+            self._shrink()
             backoff = min(
                 self.capacity.backoff_initial_seconds * (2 ** (self._consecutive_failures - 1)),
                 self.capacity.backoff_max_seconds,
@@ -229,6 +275,7 @@ class ProviderOverloadController:
             self._consecutive_failures = 0
             return BackoffDecision(False, 0.0, False, "non-retryable provider error")
         self._consecutive_failures += 1
+        self._shrink()
         backoff = min(
             self.capacity.backoff_initial_seconds * (2 ** (self._consecutive_failures - 1)),
             self.capacity.backoff_max_seconds,

--- a/src/paperscale/providers/self_hosted.py
+++ b/src/paperscale/providers/self_hosted.py
@@ -219,6 +219,27 @@ class ProviderOverloadController:
         self._consecutive_failures = 0
         return BackoffDecision(False, 0.0, False, f"non-retryable HTTP {status_code}")
 
+    def record_failure(self, *, retryable: bool) -> BackoffDecision:
+        """Account for a provider transport failure surfaced as an exception.
+
+        Transport-agnostic counterpart to record_status: callers that only see
+        exceptions (no HTTP status) use this to drive backoff and the circuit breaker.
+        """
+        if not retryable:
+            self._consecutive_failures = 0
+            return BackoffDecision(False, 0.0, False, "non-retryable provider error")
+        self._consecutive_failures += 1
+        backoff = min(
+            self.capacity.backoff_initial_seconds * (2 ** (self._consecutive_failures - 1)),
+            self.capacity.backoff_max_seconds,
+        )
+        return BackoffDecision(
+            should_retry=not self.circuit_open,
+            backoff_seconds=backoff,
+            circuit_open=self.circuit_open,
+            diagnostic="provider transport error",
+        )
+
 
 class HttpClient(Protocol):
     def get(self, url: str, *, timeout: float) -> Any: ...

--- a/src/paperscale/rendering.py
+++ b/src/paperscale/rendering.py
@@ -1,13 +1,36 @@
-"""PDF page rendering adapters for document-to-Markdown OCR."""
+"""PDF page rendering for document-to-Markdown OCR.
+
+Rasterizes with **PDFium** (``pypdfium2``), which renders the full range of
+real-world PDFs — including scanned pages stored as ImageMask / CCITT / JBIG2
+stencil masks. (The earlier ``pdf_oxide`` backend silently skipped those XObjects,
+yielding a blank image and therefore empty OCR.) Rendering stays lazy: one page is
+decoded on demand at a time.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 import hashlib
+import io
 from pathlib import Path
 from typing import Any
 
-from pdf_oxide import PdfDocument
+import pypdfium2 as pdfium
+from PIL import Image
+
+
+def png_dark_fraction(image_bytes: bytes) -> float:
+    """Fraction of non-near-white pixels in a PNG — a cheap "how much ink" measure.
+
+    Used to distinguish a genuinely blank page (which legitimately OCRs to empty)
+    from a content page the model failed to read. Near-blank scans sit around
+    0.002–0.005; content pages are an order of magnitude higher.
+    """
+    image = Image.open(io.BytesIO(image_bytes)).convert("L")
+    histogram = image.histogram()
+    total = sum(histogram) or 1
+    dark = sum(histogram[:230])
+    return dark / total
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,27 +44,40 @@ class RenderedPage:
     render_options: dict[str, Any] = field(default_factory=dict)
 
 
+# Resolution bounds. ``target_longest_side`` is honored when no explicit ``dpi`` is
+# given; both are clamped so a remediation DPI bump cannot produce a runaway bitmap.
+_DEFAULT_DPI = 144.0
+_MIN_SCALE = 0.2
+_MAX_LONGEST_SIDE_PX = 4000
+
+
 class PdfPageRenderer:
     """Render PDF pages as PNG bytes while exposing a 1-based public API."""
 
     def __init__(self, path: Path | str, *, render_options: dict[str, Any] | None = None) -> None:
         self.path = Path(path)
         self.render_options = dict(render_options or {})
-        self._document = PdfDocument(str(self.path))
+        image_format = str(self.render_options.get("image_format", "png"))
+        if image_format != "png":
+            raise ValueError("v1 OCR rendering only supports PNG output")
+        self._document = pdfium.PdfDocument(str(self.path))
 
     @property
     def page_count(self) -> int:
-        return int(self._document.page_count())
+        return int(len(self._document))
 
     def render_page(self, page_number: int) -> RenderedPage:
         if page_number < 1 or page_number > self.page_count:
             raise ValueError(f"page_number must be between 1 and {self.page_count}, got {page_number}")
-        page_index = page_number - 1
-        image_format = str(self.render_options.get("image_format", "png"))
-        if image_format != "png":
-            raise ValueError("v1 OCR rendering only supports PNG output")
-        dpi = self.render_options.get("dpi")
-        image_bytes = self._document.render_page(page_index, dpi=dpi, format="png")
+        page = self._document[page_number - 1]
+        width_pt, height_pt = page.get_size()
+        scale = self._scale_for(float(width_pt), float(height_pt))
+        pil_image = page.render(scale=scale).to_pil()
+        if pil_image.mode not in ("RGB", "L"):
+            pil_image = pil_image.convert("RGB")
+        buffer = io.BytesIO()
+        pil_image.save(buffer, format="PNG")
+        image_bytes = buffer.getvalue()
         return RenderedPage(
             page_number=page_number,
             image_bytes=image_bytes,
@@ -49,3 +85,19 @@ class PdfPageRenderer:
             media_type="image/png",
             render_options=dict(self.render_options),
         )
+
+    def _scale_for(self, width_pt: float, height_pt: float) -> float:
+        """PDFium render scale (pixels per point; 1.0 == 72 dpi).
+
+        Priority: explicit ``dpi`` (set by render remediation) > ``target_longest_side``
+        (honored exactly) > a sensible default.
+        """
+        dpi = self.render_options.get("dpi")
+        if dpi:
+            return max(_MIN_SCALE, float(dpi) / 72.0)
+        target = self.render_options.get("target_longest_side")
+        longest_pt = max(width_pt, height_pt, 1.0)
+        if target:
+            target_px = min(float(target), float(_MAX_LONGEST_SIDE_PX))
+            return max(_MIN_SCALE, target_px / longest_pt)
+        return _DEFAULT_DPI / 72.0

--- a/src/paperscale/runner.py
+++ b/src/paperscale/runner.py
@@ -20,6 +20,7 @@ from paperscale.providers.openai_chat import OpenAIChatProvider
 from paperscale.providers.self_hosted import (
     InferenceServerProfile,
     ProviderCapacityProfile,
+    ProviderOverloadController,
     SelfHostedOpenAICompatibleProvider,
     builtin_capacity_profile,
 )
@@ -421,7 +422,11 @@ class DocumentOcrRunner:
         retry_ambiguous: bool,
     ) -> JobStatus:
         profile = get_builtin_profile(manifest.profile)
+        capacity = self._capacity_for(manifest)
+        overload = ProviderOverloadController(capacity)
         for page_number in range(1, manifest.page_count + 1):
+            if overload.circuit_open:
+                break
             page = pages[str(page_number)]
             state = page.get("state")
             if state == "succeeded":
@@ -430,14 +435,25 @@ class DocumentOcrRunner:
                 continue
             if state not in {"pending", "failed_retryable", "reserved", "ambiguous"}:
                 continue
-            rendered = renderer.render_page(page_number)
-            request = profile.build_request(
-                f"{manifest.document_id}:{page_number}",
-                rendered.image_bytes,
-                getattr(rendered, "media_type", "image/png"),
-                model=manifest.model,
-            )
-            self._process_page(manifest, pages, page_number, request)
+            with self.governor.acquire(ResourceKind.SCHEDULER):
+                with self.governor.acquire(ResourceKind.RENDER):
+                    rendered = renderer.render_page(page_number)
+                request = profile.build_request(
+                    f"{manifest.document_id}:{page_number}",
+                    rendered.image_bytes,
+                    getattr(rendered, "media_type", "image/png"),
+                    model=manifest.model,
+                )
+                while True:
+                    outcome = self._process_page(manifest, pages, page_number, request)
+                    if outcome.status != "transport_error":
+                        if outcome.status == "succeeded":
+                            overload.record_success()
+                        break
+                    decision = overload.record_failure(retryable=True)
+                    if not decision.should_retry:
+                        break
+                    self._sleep(decision.backoff_seconds)
         self._assemble_if_ready(manifest, pages, allow_partial=allow_partial)
         return self._write_indexes(manifest, pages, partial=allow_partial and _count_states(pages).get("succeeded", 0) < manifest.page_count)
 
@@ -447,97 +463,101 @@ class DocumentOcrRunner:
             return self.provider
         return _default_provider(manifest.base_url)
 
-    def _process_page(self, manifest: JobManifest, pages: Json, page_number: int, request: Any) -> None:
+    def _process_page(self, manifest: JobManifest, pages: Json, page_number: int, request: Any) -> _PageOutcome:
         page_key = str(page_number)
         previous = pages[page_key]
         epoch = int(previous.get("epoch") or 0) + 1
         attempt_id = str(uuid.uuid4())
         now = float(self.clock())
-        attempt = {
-            "schema_version": CURRENT_SCHEMA_VERSION,
-            "kind": "page_attempt",
-            "attempt_id": attempt_id,
-            "job_id": manifest.job_id,
-            "page_id": request.page_id,
-            "page_number": page_number,
-            "state": "reserved",
-            "fingerprint": request.fingerprint,
-            "worker_id": self.config.worker_id,
-            "epoch": epoch,
-            "lease_expires_at": now + self.config.lease_seconds,
-            "heartbeat_at": now,
-            "provider_started_at": None,
-            "provider_response_committed_at": None,
-            "result_pointer": None,
-            "diagnostic": None,
-        }
-        self._write_ledger(manifest.job_id, attempt_id, attempt)
-        pages[page_key] = {
-            "state": "reserved",
-            "epoch": epoch,
-            "attempt_id": attempt_id,
-            "fingerprint": request.fingerprint,
-        }
-        self._write_indexes(manifest, pages, partial=False)
+        with self.governor.acquire(ResourceKind.PROVIDER):
+            with self.governor.acquire(ResourceKind.PAGE_LEASE):
+                attempt = {
+                    "schema_version": CURRENT_SCHEMA_VERSION,
+                    "kind": "page_attempt",
+                    "attempt_id": attempt_id,
+                    "job_id": manifest.job_id,
+                    "page_id": request.page_id,
+                    "page_number": page_number,
+                    "state": "reserved",
+                    "fingerprint": request.fingerprint,
+                    "worker_id": self.config.worker_id,
+                    "epoch": epoch,
+                    "lease_expires_at": now + self.config.lease_seconds,
+                    "heartbeat_at": now,
+                    "provider_started_at": None,
+                    "provider_response_committed_at": None,
+                    "result_pointer": None,
+                    "diagnostic": None,
+                }
+                self._write_ledger(manifest.job_id, attempt_id, attempt)
+                pages[page_key] = {
+                    "state": "reserved",
+                    "epoch": epoch,
+                    "attempt_id": attempt_id,
+                    "fingerprint": request.fingerprint,
+                }
+                self._write_indexes(manifest, pages, partial=False)
 
-        attempt = {**attempt, "state": "in_flight", "provider_started_at": float(self.clock())}
-        self._write_ledger(manifest.job_id, attempt_id, attempt)
-        pages[page_key] = {**pages[page_key], "state": "in_flight"}
-        self._write_indexes(manifest, pages, partial=False)
+                attempt = {**attempt, "state": "in_flight", "provider_started_at": float(self.clock())}
+                self._write_ledger(manifest.job_id, attempt_id, attempt)
+                pages[page_key] = {**pages[page_key], "state": "in_flight"}
+                self._write_indexes(manifest, pages, partial=False)
 
-        try:
-            response = self._provider_for(manifest).send(request)
-        except Exception as exc:
-            self._fail_attempt(manifest, pages, page_number, attempt, state="failed_retryable", diagnostic=str(exc))
-            return
+                try:
+                    response = self._provider_for(manifest).send(request)
+                except Exception as exc:
+                    self._fail_attempt(manifest, pages, page_number, attempt, state="failed_retryable", diagnostic=str(exc))
+                    return _PageOutcome("transport_error")
 
-        parsed = get_builtin_profile(manifest.profile).parse_and_validate(response.markdown)
-        if not parsed.ok:
-            state = "failed_terminal" if parsed.retry_classification == "terminal" else "failed_retryable"
-            self._fail_attempt(manifest, pages, page_number, attempt, state=state, diagnostic=parsed.diagnostic)
-            return
-        finding = self.verifier.classify(parsed.markdown)
-        if not finding.accepted:
-            state = "failed_terminal" if finding.retry_class == "terminal" else "failed_retryable"
-            self._fail_attempt(manifest, pages, page_number, attempt, state=state, diagnostic=finding.kind)
-            return
+                parsed = get_builtin_profile(manifest.profile).parse_and_validate(response.markdown)
+                if not parsed.ok:
+                    state = "failed_terminal" if parsed.retry_classification == "terminal" else "failed_retryable"
+                    self._fail_attempt(manifest, pages, page_number, attempt, state=state, diagnostic=parsed.diagnostic)
+                    return _PageOutcome("content_failure")
+                finding = self.verifier.classify(parsed.markdown)
+                if not finding.accepted:
+                    state = "failed_terminal" if finding.retry_class == "terminal" else "failed_retryable"
+                    self._fail_attempt(manifest, pages, page_number, attempt, state=state, diagnostic=finding.kind)
+                    return _PageOutcome("content_failure")
 
-        artifact_rel = self._artifact_rel(manifest.job_id, page_number)
-        artifact = {
-            "schema_version": CURRENT_SCHEMA_VERSION,
-            "kind": "page_artifact",
-            "document_id": manifest.document_id,
-            "page_number": page_number,
-            "page_id": request.page_id,
-            "markdown": parsed.markdown,
-            "result_pointer": str(artifact_rel),
-            "verifier_metadata": [finding.__dict__ if hasattr(finding, "__dict__") else {
-                "accepted": finding.accepted,
-                "kind": finding.kind,
-                "retry_class": finding.retry_class,
-                "warnings": list(finding.warnings),
-            }],
-            "fingerprint": request.fingerprint,
-            "image_hash": request.image_hash,
-            "provider_request_id": response.provider_request_id,
-            "provider_metadata": response.metadata,
-            "profile_metadata": parsed.metadata,
-        }
-        self.state.write_json_atomic(artifact_rel, artifact)
-        committed = {
-            **attempt,
-            "state": "succeeded",
-            "provider_response_committed_at": float(self.clock()),
-            "result_pointer": str(artifact_rel),
-        }
-        self._write_ledger(manifest.job_id, attempt_id, committed)
-        pages[page_key] = {
-            **pages[page_key],
-            "state": "succeeded",
-            "artifact_path": str(artifact_rel),
-            "fingerprint": request.fingerprint,
-        }
-        self._write_indexes(manifest, pages, partial=False)
+                artifact_rel = self._artifact_rel(manifest.job_id, page_number)
+                artifact = {
+                    "schema_version": CURRENT_SCHEMA_VERSION,
+                    "kind": "page_artifact",
+                    "document_id": manifest.document_id,
+                    "page_number": page_number,
+                    "page_id": request.page_id,
+                    "markdown": parsed.markdown,
+                    "result_pointer": str(artifact_rel),
+                    "verifier_metadata": [finding.__dict__ if hasattr(finding, "__dict__") else {
+                        "accepted": finding.accepted,
+                        "kind": finding.kind,
+                        "retry_class": finding.retry_class,
+                        "warnings": list(finding.warnings),
+                    }],
+                    "fingerprint": request.fingerprint,
+                    "image_hash": request.image_hash,
+                    "provider_request_id": response.provider_request_id,
+                    "provider_metadata": response.metadata,
+                    "profile_metadata": parsed.metadata,
+                }
+                with self.governor.acquire(ResourceKind.STATE_STORE):
+                    self.state.write_json_atomic(artifact_rel, artifact)
+                committed = {
+                    **attempt,
+                    "state": "succeeded",
+                    "provider_response_committed_at": float(self.clock()),
+                    "result_pointer": str(artifact_rel),
+                }
+                self._write_ledger(manifest.job_id, attempt_id, committed)
+                pages[page_key] = {
+                    **pages[page_key],
+                    "state": "succeeded",
+                    "artifact_path": str(artifact_rel),
+                    "fingerprint": request.fingerprint,
+                }
+                self._write_indexes(manifest, pages, partial=False)
+                return _PageOutcome("succeeded")
 
     def _fail_attempt(self, manifest: JobManifest, pages: Json, page_number: int, attempt: Json, *, state: str, diagnostic: str) -> None:
         failed = {**attempt, "state": state, "diagnostic": diagnostic}

--- a/src/paperscale/runner.py
+++ b/src/paperscale/runner.py
@@ -13,7 +13,7 @@ import uuid
 import urllib.request
 
 from paperscale.assembly import MarkdownAssembler
-from paperscale.contracts import CURRENT_SCHEMA_VERSION, PageArtifact
+from paperscale.contracts import CURRENT_SCHEMA_VERSION, PageArtifact, ensure_known_schema
 from paperscale.profiles.builtin import get_builtin_profile
 from paperscale.providers.base import PageOcrProvider
 from paperscale.providers.openai_chat import OpenAIChatProvider
@@ -210,22 +210,166 @@ class DocumentOcrRunner:
         return self._read_index(job_id, "reconcile")
 
     def fsck(self, job_id: str) -> Json:
+        """Scan-only ledger/index/artifact triangulation. Never mutates state."""
         manifest = self._read_manifest(job_id)
         status_index = self._read_index(job_id, "status")
-        issues: list[Json] = []
         pages = status_index.get("pages", {})
-        for page_text, page in pages.items():
-            if isinstance(page, dict) and page.get("state") == "succeeded":
-                artifact = self._artifact_rel(job_id, int(page_text))
-                if not (self.state.root / artifact).exists():
-                    issues.append({"code": "missing_artifact", "page_number": int(page_text), "path": str(artifact)})
-        artifact_dir = self._job_dir(job_id) / "artifacts" / "pages"
-        if artifact_dir.exists():
-            known = set(pages)
-            for artifact in artifact_dir.glob("*.json"):
-                if artifact.stem not in known:
-                    issues.append({"code": "orphan_artifact", "page_number": artifact.stem})
+        if not isinstance(pages, dict):
+            raise CompactIndexError(f"missing pages in status index for {job_id}")
+        ledger_by_page = self._ledger_attempts_by_page(job_id)
+        issues: list[Json] = []
+        for page_number in range(1, manifest.page_count + 1):
+            page = pages.get(str(page_number))
+            if not isinstance(page, dict):
+                issues.append({"code": "missing_page", "page_number": page_number})
+                continue
+            state = page.get("state")
+            if state == "succeeded":
+                issues.extend(self._fsck_succeeded_page(job_id, page_number, page, ledger_by_page))
+            elif state in {"reserved", "in_flight"}:
+                issues.append({
+                    "code": "stale_lease",
+                    "page_number": page_number,
+                    "state": state,
+                    "lease_expires_at": self._ledger_lease(job_id, page.get("attempt_id")),
+                })
+        issues.extend(self._fsck_orphan_artifacts(job_id, pages))
+        issues.extend(self._fsck_count_mismatches(manifest, status_index, pages))
         return {"job_id": job_id, "scanned": True, "pages_total": manifest.page_count, "issues": issues}
+
+    def _fsck_succeeded_page(self, job_id: str, page_number: int, page: Json, ledger_by_page: dict[int, list[Json]]) -> list[Json]:
+        found: list[Json] = []
+        artifact_rel = self._artifact_rel(job_id, page_number)
+        if not (self.state.root / artifact_rel).exists():
+            found.append({"code": "missing_artifact", "page_number": page_number, "path": str(artifact_rel)})
+        else:
+            artifact = self.state.read_json(artifact_rel)
+            ensure_known_schema(artifact)
+            indexed = page.get("fingerprint")
+            if indexed is not None and artifact.get("fingerprint") != indexed:
+                found.append({
+                    "code": "fingerprint_mismatch",
+                    "page_number": page_number,
+                    "indexed": indexed,
+                    "artifact": artifact.get("fingerprint"),
+                })
+        if not any(attempt.get("state") == "succeeded" for attempt in ledger_by_page.get(page_number, [])):
+            found.append({
+                "code": "ledger_mismatch",
+                "page_number": page_number,
+                "detail": "succeeded page has no terminal-succeeded ledger attempt",
+            })
+        return found
+
+    def _fsck_orphan_artifacts(self, job_id: str, pages: Json) -> list[Json]:
+        artifact_dir = self._job_dir(job_id) / "artifacts" / "pages"
+        if not artifact_dir.exists():
+            return []
+        known = set(pages)
+        return [
+            {"code": "orphan_artifact", "page_number": artifact.stem}
+            for artifact in sorted(artifact_dir.glob("*.json"))
+            if artifact.stem not in known
+        ]
+
+    def _fsck_count_mismatches(self, manifest: JobManifest, status_index: Json, pages: Json) -> list[Json]:
+        found: list[Json] = []
+        actual = _count_states(pages)
+        for field in ("succeeded", "failed_retryable", "failed_terminal", "ambiguous", "pending"):
+            indexed = int(status_index.get(field, 0))
+            if actual.get(field, 0) != indexed:
+                found.append({"code": "count_mismatch", "field": field, "indexed": indexed, "actual": actual.get(field, 0)})
+        if len(pages) != manifest.page_count:
+            found.append({"code": "count_mismatch", "field": "pages_total", "indexed": manifest.page_count, "actual": len(pages)})
+        return found
+
+    def _ledger_attempts_by_page(self, job_id: str) -> dict[int, list[Json]]:
+        result: dict[int, list[Json]] = {}
+        ledger_dir = self._job_dir(job_id) / "ledger"
+        if not ledger_dir.exists():
+            return result
+        for path in sorted(ledger_dir.glob("*.json")):
+            try:
+                record = self.state.read_json(self._ledger_rel(job_id, path.stem))
+            except (FileNotFoundError, json.JSONDecodeError):
+                continue
+            ensure_known_schema(record)
+            page_number = record.get("page_number")
+            if isinstance(page_number, int):
+                result.setdefault(page_number, []).append(record)
+        return result
+
+    def _ledger_lease(self, job_id: str, attempt_id: Any) -> float | None:
+        if not isinstance(attempt_id, str):
+            return None
+        try:
+            attempt = self.state.read_json(self._ledger_rel(job_id, attempt_id))
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+        ensure_known_schema(attempt)
+        lease = attempt.get("lease_expires_at")
+        return float(lease) if isinstance(lease, (int, float)) else None
+
+    def resolve_ambiguous(self, job_id: str, page_number: int, *, action: str) -> JobStatus:
+        """Operator action to resolve an ambiguous page by superseding its attempt.
+
+        ``supersede`` discards the uncertain attempt and requeues the page (pending);
+        ``accept`` adopts the page's already-written artifact and marks it succeeded.
+        Both record the prior attempt as ``superseded`` in the ledger.
+        """
+        if action not in {"supersede", "accept"}:
+            raise ValueError(f"unknown reconcile action {action!r}")
+        manifest = self._read_manifest(job_id)
+        pages = self._read_pages_from_status(job_id)
+        entry = pages.get(str(page_number))
+        if not isinstance(entry, dict):
+            raise ValueError(f"unknown page {page_number} for job {job_id!r}")
+        if entry.get("state") != "ambiguous":
+            raise ValueError(f"page {page_number} is not ambiguous (state={entry.get('state')!r})")
+        if action == "accept":
+            pages[str(page_number)] = self._accept_ambiguous_artifact(job_id, page_number, entry)
+        else:
+            pages[str(page_number)] = {
+                "state": "pending",
+                "epoch": int(entry.get("epoch") or 0),
+                "attempt_id": None,
+                "fingerprint": None,
+                "duplicate_call_risk": False,
+            }
+        self._supersede_attempt(job_id, page_number, entry, resolution="accepted" if action == "accept" else "discarded")
+        self._assemble_if_ready(manifest, pages, allow_partial=False)
+        return self._write_indexes(manifest, pages, partial=False)
+
+    def _accept_ambiguous_artifact(self, job_id: str, page_number: int, entry: Json) -> Json:
+        artifact_rel = self._artifact_rel(job_id, page_number)
+        if not (self.state.root / artifact_rel).exists():
+            raise FileNotFoundError(f"no artifact to accept for page {page_number} of job {job_id!r}")
+        artifact = self.state.read_json(artifact_rel)
+        ensure_known_schema(artifact)
+        return {
+            "state": "succeeded",
+            "artifact_path": str(artifact_rel),
+            "fingerprint": artifact.get("fingerprint"),
+            "epoch": int(entry.get("epoch") or 0),
+        }
+
+    def _supersede_attempt(self, job_id: str, page_number: int, entry: Json, *, resolution: str) -> None:
+        attempt_id = entry.get("attempt_id")
+        if not isinstance(attempt_id, str):
+            return
+        try:
+            attempt = self.state.read_json(self._ledger_rel(job_id, attempt_id))
+            ensure_known_schema(attempt)
+        except (FileNotFoundError, json.JSONDecodeError):
+            attempt = {
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "kind": "page_attempt",
+                "attempt_id": attempt_id,
+                "job_id": job_id,
+                "page_number": page_number,
+            }
+        superseded = {**attempt, "state": "superseded", "resolution": resolution, "resolved_at": float(self.clock())}
+        self._write_ledger(job_id, attempt_id, superseded)
 
     def repair_index(self, job_id: str) -> JobStatus:
         manifest = self._read_manifest(job_id)
@@ -237,6 +381,7 @@ class DocumentOcrRunner:
             artifact_path = self.state.root / self._artifact_rel(job_id, page_number)
             if artifact_path.exists():
                 artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+                ensure_known_schema(artifact)
                 pages[page_key] = {
                     **old,
                     "state": "succeeded",
@@ -390,6 +535,7 @@ class DocumentOcrRunner:
         artifacts: list[PageArtifact] = []
         for page_number in sorted(succeeded_pages):
             payload = self.state.read_json(self._artifact_rel(manifest.job_id, page_number))
+            ensure_known_schema(payload)
             artifacts.append(
                 PageArtifact(
                     page_id=str(payload["page_id"]),
@@ -417,6 +563,7 @@ class DocumentOcrRunner:
                 attempt = self.state.read_json(attempt_path)
             except FileNotFoundError:
                 continue
+            ensure_known_schema(attempt)
             if float(attempt.get("lease_expires_at", now + 1)) > now:
                 continue
             if attempt.get("state") == "reserved" and attempt.get("provider_started_at") is None:
@@ -436,7 +583,9 @@ class DocumentOcrRunner:
         self.state.write_json_atomic(self._manifest_rel(manifest.job_id), manifest.to_json())
 
     def _read_manifest(self, job_id: str) -> JobManifest:
-        return JobManifest.from_json(self.state.read_json(self._manifest_rel(job_id)))
+        payload = self.state.read_json(self._manifest_rel(job_id))
+        ensure_known_schema(payload)
+        return JobManifest.from_json(payload)
 
     def _read_index(self, job_id: str, name: str) -> Json:
         try:
@@ -445,6 +594,7 @@ class DocumentOcrRunner:
             raise CompactIndexError(f"missing or corrupt {name} index for {job_id}") from exc
         if not isinstance(payload, dict):
             raise CompactIndexError(f"missing or corrupt {name} index for {job_id}")
+        ensure_known_schema(payload)
         return payload
 
     def _read_pages_from_status(self, job_id: str) -> Json:
@@ -488,6 +638,7 @@ class DocumentOcrRunner:
                     "page_number": int(page),
                     "attempt_id": entry.get("attempt_id"),
                     "duplicate_call_risk": True,
+                    "recommended_actions": ["supersede", "accept"],
                 }
                 for page, entry in pages.items()
                 if isinstance(entry, dict) and entry.get("state") == "ambiguous"

--- a/src/paperscale/runner.py
+++ b/src/paperscale/runner.py
@@ -19,9 +19,11 @@ from paperscale.providers.base import PageOcrProvider
 from paperscale.providers.openai_chat import OpenAIChatProvider
 from paperscale.providers.self_hosted import (
     InferenceServerProfile,
+    ProviderCapacityProfile,
     SelfHostedOpenAICompatibleProvider,
     builtin_capacity_profile,
 )
+from paperscale.resources import ResourceGovernor, ResourceKind
 from paperscale.quality.verifier import DeterministicQualityVerifier
 from paperscale.rendering import PdfPageRenderer
 from paperscale.scheduler import CompactIndexError
@@ -29,6 +31,13 @@ from paperscale.state.fs_store import FileSystemStateStore
 
 Json = dict[str, Any]
 RendererFactory = Callable[[Path, dict[str, Any]], Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _PageOutcome:
+    """Result of a single page attempt, used to drive retry/circuit decisions."""
+
+    status: str  # "succeeded" | "transport_error" | "content_failure"
 
 
 @dataclass(frozen=True, slots=True)
@@ -149,6 +158,8 @@ class DocumentOcrRunner:
         provider: PageOcrProvider | None = None,
         renderer_factory: RendererFactory | None = None,
         clock: Callable[[], float] | None = None,
+        governor: ResourceGovernor | None = None,
+        sleeper: Callable[[float], None] | None = None,
     ) -> None:
         self.config = config or RunnerConfig()
         self.state = FileSystemStateStore(Path(self.config.state_root))
@@ -156,6 +167,8 @@ class DocumentOcrRunner:
         self.renderer_factory = renderer_factory or (lambda path, options: PdfPageRenderer(path, render_options=options))
         self.clock = clock or time.time
         self.verifier = DeterministicQualityVerifier()
+        self.governor = governor or ResourceGovernor()
+        self._sleep = sleeper or time.sleep
 
     def run(
         self,
@@ -392,6 +405,12 @@ class DocumentOcrRunner:
                 pages[page_key] = {**old, "state": "failed_retryable", "artifact_path": None}
         return self._write_indexes(manifest, pages, partial=False)
 
+    def _capacity_for(self, manifest: JobManifest) -> ProviderCapacityProfile:
+        try:
+            return builtin_capacity_profile(manifest.capacity)
+        except ValueError:
+            return builtin_capacity_profile("local-vllm-small")
+
     def _process_pages(
         self,
         manifest: JobManifest,
@@ -580,7 +599,8 @@ class DocumentOcrRunner:
             self._write_indexes(manifest, pages, partial=False)
 
     def _write_manifest(self, manifest: JobManifest) -> None:
-        self.state.write_json_atomic(self._manifest_rel(manifest.job_id), manifest.to_json())
+        with self.governor.acquire(ResourceKind.STATE_STORE):
+            self.state.write_json_atomic(self._manifest_rel(manifest.job_id), manifest.to_json())
 
     def _read_manifest(self, job_id: str) -> JobManifest:
         payload = self.state.read_json(self._manifest_rel(job_id))
@@ -644,13 +664,15 @@ class DocumentOcrRunner:
                 if isinstance(entry, dict) and entry.get("state") == "ambiguous"
             ],
         }
-        self.state.write_json_atomic(self._index_rel(manifest.job_id, "status"), status_index)
-        self.state.write_json_atomic(self._index_rel(manifest.job_id, "resume"), resume_index)
-        self.state.write_json_atomic(self._index_rel(manifest.job_id, "reconcile"), reconcile_index)
+        with self.governor.acquire(ResourceKind.STATE_STORE):
+            self.state.write_json_atomic(self._index_rel(manifest.job_id, "status"), status_index)
+            self.state.write_json_atomic(self._index_rel(manifest.job_id, "resume"), resume_index)
+            self.state.write_json_atomic(self._index_rel(manifest.job_id, "reconcile"), reconcile_index)
         return JobStatus.from_index(status_index)
 
     def _write_ledger(self, job_id: str, attempt_id: str, payload: Json) -> None:
-        self.state.write_json_atomic(self._ledger_rel(job_id, attempt_id), payload)
+        with self.governor.acquire(ResourceKind.STATE_STORE):
+            self.state.write_json_atomic(self._ledger_rel(job_id, attempt_id), payload)
 
     def _job_dir(self, job_id: str) -> Path:
         return self.state.root / "jobs" / job_id

--- a/src/paperscale/runner.py
+++ b/src/paperscale/runner.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
+import inspect
 import json
 import os
 from pathlib import Path
@@ -12,11 +14,11 @@ from typing import Any, Callable
 import uuid
 import urllib.request
 
+from paperscale.async_pool import AdaptiveLimiter
 from paperscale.assembly import MarkdownAssembler
 from paperscale.contracts import CURRENT_SCHEMA_VERSION, PageArtifact, ensure_known_schema
 from paperscale.profiles.builtin import get_builtin_profile
 from paperscale.providers.base import PageOcrProvider
-from paperscale.providers.openai_chat import OpenAIChatProvider
 from paperscale.providers.self_hosted import (
     InferenceServerProfile,
     ProviderCapacityProfile,
@@ -26,19 +28,126 @@ from paperscale.providers.self_hosted import (
 )
 from paperscale.resources import ResourceGovernor, ResourceKind
 from paperscale.quality.verifier import DeterministicQualityVerifier
-from paperscale.rendering import PdfPageRenderer
+from paperscale.rendering import PdfPageRenderer, png_dark_fraction
 from paperscale.scheduler import CompactIndexError
 from paperscale.state.fs_store import FileSystemStateStore
 
 Json = dict[str, Any]
 RendererFactory = Callable[[Path, dict[str, Any]], Any]
 
+# Document-claim lease/heartbeat (single-machine multi-process tier). Heartbeat is
+# ~lease/3 so a brief stall does not lose the claim, per concurrency-and-queuing.md.
+_CLAIM_LEASE_SECONDS = 60.0
+_CLAIM_HEARTBEAT_SECONDS = 20.0
+
+# A page whose rendered image has less ink than this is treated as genuinely blank:
+# an empty OCR result for it is accepted as a successful empty page rather than a
+# failure. Blank scans sit ~0.002-0.005; content pages are an order of magnitude more.
+_BLANK_INK_THRESHOLD = 0.01
+
+# Diagnostics that mean "no readable content was produced" — on a near-blank render
+# these indicate a genuinely blank page (empty output, or a VLM repetition loop on
+# noise), so the page is accepted as blank rather than failed.
+_BLANK_ELIGIBLE_DIAGNOSTICS = frozenset({"empty_output", "repeated_ngram", "repeated_character"})
+
+
+def _render_is_blank(image_bytes: bytes) -> bool:
+    try:
+        return png_dark_fraction(image_bytes) < _BLANK_INK_THRESHOLD
+    except Exception:  # noqa: BLE001 - never let a blank-check error fail a page
+        return False
+
 
 @dataclass(frozen=True, slots=True)
-class _PageOutcome:
-    """Result of a single page attempt, used to drive retry/circuit decisions."""
+class _AttemptResult:
+    """Outcome of one provider attempt within a page's retry/remediation ladder."""
 
-    status: str  # "succeeded" | "transport_error" | "content_failure"
+    kind: str  # "succeeded" | "terminal" | "transport" | "content_retryable"
+    diagnostic: str
+    should_retry: bool
+    backoff: float
+
+
+@dataclass(slots=True)
+class _RunContext:
+    """Shared state for the asyncio worker pool of one job run."""
+
+    profile: Any
+    provider: Any
+    renderer: Any
+    overload: Any
+    limiter: AdaptiveLimiter
+    writer: "_IndexWriter"
+    render_lock: asyncio.Lock
+    manifest: "JobManifest"
+    pages: dict[str, Any]
+    retry_ambiguous: bool
+
+
+_WRITER_CLOSE = object()
+
+
+class _IndexWriter:
+    """Single serialized writer for the eventually-consistent compact indexes.
+
+    Workers never write the indexes; they push tiny page-state events onto a queue.
+    This one task owns the authoritative in-memory ``pages`` and regenerates all
+    three indexes together (so they stay mutually consistent), with a coalesced
+    flush cadence of ``max(64 events, 250 ms)`` plus an immediate flush on notable
+    events (terminal failure / settle / completion). Index writes are atomic but
+    NOT fsync'd — they are a derived, rebuildable rollup of the fsync'd truth.
+    """
+
+    _FLUSH_EVENTS = 64
+    _FLUSH_INTERVAL = 0.25
+
+    def __init__(self, runner: "DocumentOcrRunner", manifest: "JobManifest", pages: dict[str, Any], *, partial: bool) -> None:
+        self._runner = runner
+        self._manifest = manifest
+        self.pages = pages
+        self._partial = partial
+        self._queue: asyncio.Queue[Any] = asyncio.Queue()
+        # Dedicated governor: the writer task must not share the runner's governor
+        # stack with worker 0 (concurrent acquire/release would corrupt the stack).
+        self._governor = ResourceGovernor()
+
+    async def publish(self, page_number: int, entry: dict[str, Any], *, notable: bool = False) -> None:
+        await self._queue.put((str(page_number), entry, notable))
+
+    async def close(self) -> None:
+        await self._queue.put(_WRITER_CLOSE)
+
+    async def run(self) -> None:
+        loop = asyncio.get_running_loop()
+        pending = 0
+        last_flush = loop.time()
+        while True:
+            timeout: float | None = None
+            if pending:
+                timeout = max(0.0, self._FLUSH_INTERVAL - (loop.time() - last_flush))
+            try:
+                item = await asyncio.wait_for(self._queue.get(), timeout) if timeout is not None else await self._queue.get()
+            except asyncio.TimeoutError:
+                self._flush()
+                pending = 0
+                last_flush = loop.time()
+                continue
+            if item is _WRITER_CLOSE:
+                if pending:
+                    self._flush()
+                return
+            key, entry, notable = item
+            self.pages[key] = entry
+            pending += 1
+            if notable or pending >= self._FLUSH_EVENTS:
+                self._flush()
+                pending = 0
+                last_flush = loop.time()
+
+    def _flush(self) -> None:
+        self._runner._write_indexes(
+            self._manifest, self.pages, partial=self._partial, fsync=False, governor=self._governor
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,6 +159,29 @@ class RunnerConfig:
     capacity: str = "local-vllm-small"
     lease_seconds: float = 300.0
     worker_id: str = "local"
+    # --- recovery/retry redesign (not persisted in the manifest; read live) ---
+    metered: bool = False
+    max_attempts: int = 8
+    # --- concurrency/queuing knobs ---
+    server_max_num_seqs: int = 128
+    # max_in_flight_requests default = 4 x server max_num_seqs (set in __post_init__).
+    max_in_flight_requests: int | None = None
+    max_open_documents: int = 128
+    render_ahead: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_in_flight_requests is None:
+            object.__setattr__(self, "max_in_flight_requests", 4 * self.server_max_num_seqs)
+        if self.render_ahead is None:
+            object.__setattr__(self, "render_ahead", self.max_in_flight_requests)
+
+    @property
+    def in_flight_limit(self) -> int:
+        return int(self.max_in_flight_requests or (4 * self.server_max_num_seqs))
+
+    @property
+    def render_ahead_limit(self) -> int:
+        return int(self.render_ahead or self.in_flight_limit)
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,6 +248,21 @@ class JobStatus:
     def complete(self) -> bool:
         return self.pages_total > 0 and self.succeeded == self.pages_total
 
+    @property
+    def settled(self) -> bool:
+        """No page can make progress on resume.
+
+        True when no ``pending``/``failed_retryable``/``in_flight``/``reserved``
+        pages remain (only ``succeeded`` + terminal). Distinguishes a job that is
+        settled-with-failures (resume is an infinite no-op) from one that still has
+        retryable work. ``in_flight`` already folds in ``reserved`` in the index.
+        """
+        return self.pending == 0 and self.failed_retryable == 0 and self.in_flight == 0
+
+    @property
+    def has_terminal_failures(self) -> bool:
+        return self.failed_terminal > 0
+
     @classmethod
     def from_index(cls, payload: Json) -> "JobStatus":
         if payload.get("kind") != "status_index":
@@ -146,6 +293,7 @@ class JobStatus:
             "partial": self.partial,
             "output_path": self.output_path,
             "complete": self.complete,
+            "settled": self.settled,
         }
 
 
@@ -169,25 +317,22 @@ class DocumentOcrRunner:
         self.clock = clock or time.time
         self.verifier = DeterministicQualityVerifier()
         self.governor = governor or ResourceGovernor()
-        self._sleep = sleeper or time.sleep
+        self._governor_injected = governor is not None
+        # Default sleeper is asyncio.sleep (non-blocking); only used inside the async
+        # pool. Tests inject a sync recorder (e.g. list.append) which is not awaited.
+        self._sleep = sleeper or asyncio.sleep
 
-    def run(
-        self,
-        *,
-        input_path: Path,
-        output_path: Path,
-        job_id: str | None = None,
-        allow_partial: bool = False,
-    ) -> JobStatus:
+    def _create_job(self, *, input_path: Path, output_path: Path, job_id: str | None) -> tuple[JobManifest, Json, Any]:
         job_id = job_id or _new_job_id(input_path)
         job_dir = self._job_dir(job_id)
         if job_dir.exists():
             raise FileExistsError(f"job {job_id!r} already exists")
-        job_dir.mkdir(parents=True)
         profile = get_builtin_profile(self.config.profile)
-        render_options = dict(profile.render_options)
-        renderer = self.renderer_factory(Path(input_path), render_options)
+        # Open the renderer and read the page count BEFORE creating the job dir, so a
+        # corrupt/unreadable PDF fails cleanly without leaving an orphan job directory.
+        renderer = self.renderer_factory(Path(input_path), dict(profile.render_options))
         page_count = int(getattr(renderer, "page_count"))
+        job_dir.mkdir(parents=True)
         model = self.config.model or profile.default_model
         manifest = JobManifest(
             job_id=job_id,
@@ -207,15 +352,142 @@ class DocumentOcrRunner:
         }
         self._write_manifest(manifest)
         self._write_indexes(manifest, pages, partial=False)
-        return self._process_pages(manifest, pages, renderer=renderer, allow_partial=allow_partial, retry_ambiguous=False)
+        return manifest, pages, renderer
+
+    def enqueue(self, *, input_path: Path, output_path: Path, job_id: str | None = None) -> str:
+        """Register a job (manifest + pending index) without processing it.
+
+        A subsequent ``work`` process (this or another) claims and runs it. This is
+        the work-queue front door for the multi-process claim tier.
+        """
+        manifest, _pages, _renderer = self._create_job(input_path=input_path, output_path=output_path, job_id=job_id)
+        return manifest.job_id
+
+    def run(
+        self,
+        *,
+        input_path: Path,
+        output_path: Path,
+        job_id: str | None = None,
+        allow_partial: bool = False,
+    ) -> JobStatus:
+        manifest, pages, renderer = self._create_job(input_path=input_path, output_path=output_path, job_id=job_id)
+        return self._process_with_claim(
+            manifest, pages, renderer=renderer, allow_partial=allow_partial, retry_ambiguous=False
+        )
 
     def resume(self, job_id: str, *, retry_ambiguous: bool = False, allow_partial: bool = False) -> JobStatus:
         manifest = self._read_manifest(job_id)
         pages = self._read_pages_from_status(job_id)
-        self._recover_expired_attempts(manifest, pages)
         profile = get_builtin_profile(manifest.profile)
         renderer = self.renderer_factory(Path(manifest.input_path), dict(profile.render_options))
-        return self._process_pages(manifest, pages, renderer=renderer, allow_partial=allow_partial, retry_ambiguous=retry_ambiguous)
+        # Reconcile (adopt-then-requeue) runs while we hold the claim so processing
+        # sees real state even if the eventually-consistent index lagged a crash.
+        return self._process_with_claim(
+            manifest, pages, renderer=renderer, allow_partial=allow_partial,
+            retry_ambiguous=retry_ambiguous, recover=True,
+        )
+
+    def work(self, *, output_dir: Path | None = None, max_jobs: int | None = None) -> list[JobStatus]:
+        """Claim and run available incomplete jobs (single machine, multi-process).
+
+        Scans the jobs tree, skips done/live-owned jobs, and resumes each job it can
+        claim. Multiple ``paperscale work`` processes can run concurrently; the
+        ``O_EXCL`` ClaimStore keeps each job single-owner and reclaims crashed owners
+        at a higher epoch. Horizontal scale = many documents across processes.
+        """
+        store = self._claim_store()
+        results: list[JobStatus] = []
+        jobs_root = self.state.root / "jobs"
+        if not jobs_root.exists():
+            return results
+        for job_dir in sorted(p for p in jobs_root.iterdir() if p.is_dir()):
+            job_id = job_dir.name
+            if store.is_done(job_id):
+                continue
+            try:
+                manifest = self._read_manifest(job_id)
+            except (FileNotFoundError, json.JSONDecodeError):
+                continue
+            claim = store.try_claim(job_id)
+            if claim is None:
+                continue  # done or owned by a live peer
+            try:
+                pages = self._read_pages_from_status(job_id)
+                profile = get_builtin_profile(manifest.profile)
+                renderer = self.renderer_factory(Path(manifest.input_path), dict(profile.render_options))
+                status = self._drive_claimed(
+                    store, claim, manifest, pages, renderer=renderer,
+                    allow_partial=False, retry_ambiguous=False, recover=True,
+                )
+                results.append(status)
+            finally:
+                store.release(claim)
+            if max_jobs is not None and len(results) >= max_jobs:
+                break
+        return results
+
+    def _claim_store(self) -> Any:
+        from paperscale.state.claim_store import ClaimStore
+
+        return ClaimStore(
+            self.state.root,
+            worker_id=self.config.worker_id,
+            clock=self.clock,
+            lease_seconds=_CLAIM_LEASE_SECONDS,
+            heartbeat_seconds=_CLAIM_HEARTBEAT_SECONDS,
+        )
+
+    def _process_with_claim(
+        self,
+        manifest: JobManifest,
+        pages: Json,
+        *,
+        renderer: Any,
+        allow_partial: bool,
+        retry_ambiguous: bool,
+        recover: bool = False,
+    ) -> JobStatus:
+        store = self._claim_store()
+        claim = store.try_claim(manifest.job_id, skip_if_done=False)
+        if claim is None:
+            raise RuntimeError(
+                f"job {manifest.job_id!r} is claimed by a live worker; cannot acquire it"
+            )
+        try:
+            return self._drive_claimed(
+                store, claim, manifest, pages, renderer=renderer,
+                allow_partial=allow_partial, retry_ambiguous=retry_ambiguous, recover=recover,
+            )
+        finally:
+            store.release(claim)
+
+    def _drive_claimed(
+        self,
+        store: Any,
+        claim: Any,
+        manifest: JobManifest,
+        pages: Json,
+        *,
+        renderer: Any,
+        allow_partial: bool,
+        retry_ambiguous: bool,
+        recover: bool,
+    ) -> JobStatus:
+        if recover:
+            self._recover_expired_attempts(manifest, pages)
+        holder = {"claim": claim}
+
+        def heartbeat() -> None:
+            holder["claim"] = store.heartbeat(holder["claim"])
+
+        status = self._process_pages(
+            manifest, pages, renderer=renderer, allow_partial=allow_partial,
+            retry_ambiguous=retry_ambiguous, heartbeat=heartbeat,
+        )
+        if status.complete:
+            store.mark_done(manifest.job_id)
+        return status
 
     def status(self, job_id: str) -> JobStatus:
         return JobStatus.from_index(self._read_index(job_id, "status"))
@@ -412,6 +684,20 @@ class DocumentOcrRunner:
         except ValueError:
             return builtin_capacity_profile("local-vllm-small")
 
+    def _provider_for(self, manifest: JobManifest) -> Any:
+        if self.provider is not None:
+            return self.provider
+        return self._build_async_provider(manifest)
+
+    def _build_async_provider(self, manifest: JobManifest) -> Any:
+        from paperscale.providers.async_openai_chat import build_async_chat_provider
+
+        return build_async_chat_provider(
+            _normalize_openai_base_url(manifest.base_url),
+            max_connections=self.config.in_flight_limit,
+            timeout=self._capacity_for(manifest).timeout_seconds,
+        )
+
     def _process_pages(
         self,
         manifest: JobManifest,
@@ -420,150 +706,391 @@ class DocumentOcrRunner:
         renderer: Any,
         allow_partial: bool,
         retry_ambiguous: bool,
+        heartbeat: Callable[[], None] | None = None,
+    ) -> JobStatus:
+        return asyncio.run(
+            self._run_pool(
+                manifest,
+                pages,
+                renderer=renderer,
+                allow_partial=allow_partial,
+                retry_ambiguous=retry_ambiguous,
+                heartbeat=heartbeat,
+            )
+        )
+
+    async def _run_pool(
+        self,
+        manifest: JobManifest,
+        pages: Json,
+        *,
+        renderer: Any,
+        allow_partial: bool,
+        retry_ambiguous: bool,
+        heartbeat: Callable[[], None] | None,
     ) -> JobStatus:
         profile = get_builtin_profile(manifest.profile)
         capacity = self._capacity_for(manifest)
-        overload = ProviderOverloadController(capacity)
+        ceiling = self.config.in_flight_limit
+        floor = max(1, min(self.config.server_max_num_seqs, ceiling))
+        overload = ProviderOverloadController(capacity, floor=floor, ceiling=ceiling)
+        limiter = AdaptiveLimiter(overload.concurrency_limit, maximum=ceiling)
+        provider = self._provider_for(manifest)
+
+        queue: asyncio.Queue[int] = asyncio.Queue()
         for page_number in range(1, manifest.page_count + 1):
-            if overload.circuit_open:
-                break
-            page = pages[str(page_number)]
-            state = page.get("state")
+            state = pages[str(page_number)].get("state")
             if state == "succeeded":
                 continue
             if state == "ambiguous" and not retry_ambiguous:
                 continue
             if state not in {"pending", "failed_retryable", "reserved", "ambiguous"}:
                 continue
-            with self.governor.acquire(ResourceKind.SCHEDULER):
-                with self.governor.acquire(ResourceKind.RENDER):
-                    rendered = renderer.render_page(page_number)
-                request = profile.build_request(
-                    f"{manifest.document_id}:{page_number}",
-                    rendered.image_bytes,
-                    getattr(rendered, "media_type", "image/png"),
-                    model=manifest.model,
-                )
-                while True:
-                    outcome = self._process_page(manifest, pages, page_number, request)
-                    if outcome.status != "transport_error":
-                        if outcome.status == "succeeded":
-                            overload.record_success()
-                        break
-                    decision = overload.record_failure(retryable=True)
-                    if not decision.should_retry:
-                        break
-                    self._sleep(decision.backoff_seconds)
+            queue.put_nowait(page_number)
+
+        writer = _IndexWriter(self, manifest, pages, partial=allow_partial)
+        writer_task = asyncio.create_task(writer.run())
+        ctx = _RunContext(
+            profile=profile,
+            provider=provider,
+            renderer=renderer,
+            overload=overload,
+            limiter=limiter,
+            writer=writer,
+            render_lock=asyncio.Lock(),
+            manifest=manifest,
+            pages=pages,
+            retry_ambiguous=retry_ambiguous,
+        )
+        worker_count = max(1, min(ceiling, self.config.render_ahead_limit, queue.qsize() or 1))
+        heartbeat_task = (
+            asyncio.create_task(self._heartbeat_loop(heartbeat)) if heartbeat is not None else None
+        )
+        try:
+            workers = [
+                asyncio.create_task(self._worker(ctx, queue, worker_index=index))
+                for index in range(worker_count)
+            ]
+            await asyncio.gather(*workers)
+        finally:
+            if heartbeat_task is not None:
+                heartbeat_task.cancel()
+            await writer.close()
+            await writer_task
+            await self._aclose_provider(provider)
+
         self._assemble_if_ready(manifest, pages, allow_partial=allow_partial)
-        return self._write_indexes(manifest, pages, partial=allow_partial and _count_states(pages).get("succeeded", 0) < manifest.page_count)
+        partial = allow_partial and _count_states(pages).get("succeeded", 0) < manifest.page_count
+        return self._write_indexes(manifest, pages, partial=partial)
 
+    async def _heartbeat_loop(self, heartbeat: Callable[[], None]) -> None:
+        try:
+            while True:
+                await asyncio.sleep(_CLAIM_HEARTBEAT_SECONDS)
+                await asyncio.to_thread(heartbeat)
+        except asyncio.CancelledError:
+            return
 
-    def _provider_for(self, manifest: JobManifest) -> PageOcrProvider:
-        if self.provider is not None:
-            return self.provider
-        return _default_provider(manifest.base_url)
+    async def _aclose_provider(self, provider: Any) -> None:
+        # Only close providers we created (the injected test provider is the caller's).
+        if provider is self.provider:
+            return
+        closer = getattr(getattr(provider, "_client", None), "close", None)
+        if closer is None:
+            return
+        try:
+            result = closer()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:  # noqa: BLE001 - best-effort cleanup
+            return
 
-    def _process_page(self, manifest: JobManifest, pages: Json, page_number: int, request: Any) -> _PageOutcome:
-        page_key = str(page_number)
-        previous = pages[page_key]
-        epoch = int(previous.get("epoch") or 0) + 1
+    async def _worker(self, ctx: "_RunContext", queue: "asyncio.Queue[int]", *, worker_index: int) -> None:
+        governor = self.governor if (worker_index == 0 and self._governor_injected) else ResourceGovernor()
+        while True:
+            if ctx.overload.circuit_open:
+                return
+            try:
+                page_number = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            try:
+                await self._process_one_page(ctx, governor, page_number)
+            finally:
+                queue.task_done()
+
+    async def _process_one_page(self, ctx: "_RunContext", governor: ResourceGovernor, page_number: int) -> None:
+        key = str(page_number)
+        entry = ctx.pages[key]
+        accumulated: dict[str, Any] = dict(entry.get("overrides") or {})
+        attempts = int(entry.get("epoch") or 0)
+        while True:
+            if ctx.overload.circuit_open:
+                return
+            if attempts >= self.config.max_attempts:
+                await self._demote_terminal(ctx, page_number, accumulated)
+                return
+            attempts += 1
+            eff_profile = (
+                ctx.profile.with_overrides(
+                    decoding=accumulated.get("decoding"), render_options=accumulated.get("render_options")
+                )
+                if accumulated
+                else ctx.profile
+            )
+            result = await self._attempt_page(ctx, governor, page_number, attempts, eff_profile, accumulated)
+            if result.kind in ("succeeded", "terminal"):
+                return
+            if result.kind == "transport":
+                if ctx.overload.circuit_open or not result.should_retry:
+                    return
+                await self._maybe_sleep(result.backoff)
+                continue
+            # content_retryable: escalate remediation on the base profile, then re-attempt.
+            accumulated = ctx.profile.remediation_for(result.diagnostic, accumulated=accumulated)
+
+    async def _attempt_page(
+        self,
+        ctx: "_RunContext",
+        governor: ResourceGovernor,
+        page_number: int,
+        epoch: int,
+        eff_profile: Any,
+        accumulated: dict[str, Any],
+    ) -> "_AttemptResult":
+        manifest = ctx.manifest
+        page_id = f"{manifest.document_id}:{page_number}"
         attempt_id = str(uuid.uuid4())
         now = float(self.clock())
-        with self.governor.acquire(ResourceKind.PROVIDER):
-            with self.governor.acquire(ResourceKind.PAGE_LEASE):
-                attempt = {
-                    "schema_version": CURRENT_SCHEMA_VERSION,
-                    "kind": "page_attempt",
-                    "attempt_id": attempt_id,
-                    "job_id": manifest.job_id,
-                    "page_id": request.page_id,
-                    "page_number": page_number,
-                    "state": "reserved",
-                    "fingerprint": request.fingerprint,
-                    "worker_id": self.config.worker_id,
-                    "epoch": epoch,
-                    "lease_expires_at": now + self.config.lease_seconds,
-                    "heartbeat_at": now,
-                    "provider_started_at": None,
-                    "provider_response_committed_at": None,
-                    "result_pointer": None,
-                    "diagnostic": None,
-                }
-                self._write_ledger(manifest.job_id, attempt_id, attempt)
-                pages[page_key] = {
-                    "state": "reserved",
-                    "epoch": epoch,
-                    "attempt_id": attempt_id,
-                    "fingerprint": request.fingerprint,
-                }
-                self._write_indexes(manifest, pages, partial=False)
+        render_override = accumulated.get("render_options")
+        with governor.acquire(ResourceKind.SCHEDULER):
+            with governor.acquire(ResourceKind.RENDER):
+                async with ctx.render_lock:
+                    if render_override:
+                        renderer = await asyncio.to_thread(
+                            self.renderer_factory, Path(manifest.input_path), dict(eff_profile.render_options)
+                        )
+                    else:
+                        renderer = ctx.renderer
+                    rendered = await asyncio.to_thread(renderer.render_page, page_number)
+            request = eff_profile.build_request(
+                page_id,
+                rendered.image_bytes,
+                getattr(rendered, "media_type", "image/png"),
+                model=manifest.model,
+            )
+            reserved_entry = {
+                "state": "reserved",
+                "epoch": epoch,
+                "attempt_id": attempt_id,
+                "fingerprint": request.fingerprint,
+                "overrides": accumulated,
+            }
+            base_attempt = {
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "kind": "page_attempt",
+                "attempt_id": attempt_id,
+                "job_id": manifest.job_id,
+                "page_id": page_id,
+                "page_number": page_number,
+                "state": "reserved",
+                "fingerprint": request.fingerprint,
+                "worker_id": self.config.worker_id,
+                "epoch": epoch,
+                "lease_expires_at": now + self.config.lease_seconds,
+                "heartbeat_at": now,
+                "provider_started_at": None,
+                "provider_response_committed_at": None,
+                "result_pointer": None,
+                "diagnostic": None,
+            }
+            with governor.acquire(ResourceKind.PROVIDER):
+                with governor.acquire(ResourceKind.PAGE_LEASE):
+                    await self._awrite_ledger(governor, manifest.job_id, attempt_id, base_attempt)
+                    await ctx.writer.publish(page_number, reserved_entry)
+                    in_flight = {**base_attempt, "state": "in_flight", "provider_started_at": float(self.clock())}
+                    await self._awrite_ledger(governor, manifest.job_id, attempt_id, in_flight)
+                    await ctx.writer.publish(page_number, {**reserved_entry, "state": "in_flight"})
+                    try:
+                        async with ctx.limiter.slot():
+                            response = await self._send(ctx.provider, request)
+                    except Exception as exc:  # noqa: BLE001 - transport/overload signal
+                        await self._awrite_ledger(
+                            governor, manifest.job_id, attempt_id,
+                            {**in_flight, "state": "failed_retryable", "diagnostic": str(exc)},
+                        )
+                        await ctx.writer.publish(
+                            page_number, {**reserved_entry, "state": "failed_retryable", "diagnostic": str(exc)}
+                        )
+                        decision = ctx.overload.record_failure(retryable=True)
+                        await ctx.limiter.set_limit(ctx.overload.concurrency_limit)
+                        return _AttemptResult("transport", str(exc), decision.should_retry, decision.backoff_seconds)
 
-                attempt = {**attempt, "state": "in_flight", "provider_started_at": float(self.clock())}
-                self._write_ledger(manifest.job_id, attempt_id, attempt)
-                pages[page_key] = {**pages[page_key], "state": "in_flight"}
-                self._write_indexes(manifest, pages, partial=False)
+                    parsed = eff_profile.parse_and_validate(response.markdown)
+                    if not parsed.ok:
+                        blank = await self._maybe_commit_blank(
+                            ctx, governor, page_number, attempt_id, in_flight, reserved_entry, request, response,
+                            diagnostic=parsed.diagnostic, image_bytes=rendered.image_bytes,
+                        )
+                        if blank is not None:
+                            return blank
+                        return await self._record_content_failure(
+                            ctx, governor, page_number, attempt_id, in_flight, reserved_entry,
+                            terminal=parsed.retry_classification == "terminal", diagnostic=parsed.diagnostic,
+                        )
+                    finding = self.verifier.classify(parsed.markdown)
+                    if not finding.accepted:
+                        blank = await self._maybe_commit_blank(
+                            ctx, governor, page_number, attempt_id, in_flight, reserved_entry, request, response,
+                            diagnostic=finding.kind, image_bytes=rendered.image_bytes,
+                        )
+                        if blank is not None:
+                            return blank
+                        return await self._record_content_failure(
+                            ctx, governor, page_number, attempt_id, in_flight, reserved_entry,
+                            terminal=finding.retry_class == "terminal", diagnostic=finding.kind,
+                        )
+                    await self._commit_success(
+                        ctx, governor, page_number, attempt_id, in_flight, reserved_entry, request, response, parsed, finding
+                    )
+                    ctx.overload.record_success()
+                    await ctx.limiter.set_limit(ctx.overload.concurrency_limit)
+                    return _AttemptResult("succeeded", "ok", False, 0.0)
 
-                try:
-                    response = self._provider_for(manifest).send(request)
-                except Exception as exc:
-                    self._fail_attempt(manifest, pages, page_number, attempt, state="failed_retryable", diagnostic=str(exc))
-                    return _PageOutcome("transport_error")
+    async def _record_content_failure(
+        self,
+        ctx: "_RunContext",
+        governor: ResourceGovernor,
+        page_number: int,
+        attempt_id: str,
+        attempt: Json,
+        reserved_entry: Json,
+        *,
+        terminal: bool,
+        diagnostic: str,
+    ) -> "_AttemptResult":
+        # Signal hygiene: a content/parse/verify rejection is NOT overload -> never throttle.
+        ctx.overload.note_content_failure()
+        state = "failed_terminal" if terminal else "failed_retryable"
+        await self._awrite_ledger(
+            governor, ctx.manifest.job_id, attempt_id, {**attempt, "state": state, "diagnostic": diagnostic}
+        )
+        await ctx.writer.publish(
+            page_number, {**reserved_entry, "state": state, "diagnostic": diagnostic}, notable=terminal
+        )
+        return _AttemptResult("terminal" if terminal else "content_retryable", diagnostic, not terminal, 0.0)
 
-                parsed = get_builtin_profile(manifest.profile).parse_and_validate(response.markdown)
-                if not parsed.ok:
-                    state = "failed_terminal" if parsed.retry_classification == "terminal" else "failed_retryable"
-                    self._fail_attempt(manifest, pages, page_number, attempt, state=state, diagnostic=parsed.diagnostic)
-                    return _PageOutcome("content_failure")
-                finding = self.verifier.classify(parsed.markdown)
-                if not finding.accepted:
-                    state = "failed_terminal" if finding.retry_class == "terminal" else "failed_retryable"
-                    self._fail_attempt(manifest, pages, page_number, attempt, state=state, diagnostic=finding.kind)
-                    return _PageOutcome("content_failure")
-
-                artifact_rel = self._artifact_rel(manifest.job_id, page_number)
-                artifact = {
-                    "schema_version": CURRENT_SCHEMA_VERSION,
-                    "kind": "page_artifact",
-                    "document_id": manifest.document_id,
-                    "page_number": page_number,
-                    "page_id": request.page_id,
-                    "markdown": parsed.markdown,
-                    "result_pointer": str(artifact_rel),
-                    "verifier_metadata": [finding.__dict__ if hasattr(finding, "__dict__") else {
-                        "accepted": finding.accepted,
-                        "kind": finding.kind,
-                        "retry_class": finding.retry_class,
-                        "warnings": list(finding.warnings),
-                    }],
-                    "fingerprint": request.fingerprint,
-                    "image_hash": request.image_hash,
-                    "provider_request_id": response.provider_request_id,
-                    "provider_metadata": response.metadata,
-                    "profile_metadata": parsed.metadata,
+    async def _commit_success(
+        self,
+        ctx: "_RunContext",
+        governor: ResourceGovernor,
+        page_number: int,
+        attempt_id: str,
+        attempt: Json,
+        reserved_entry: Json,
+        request: Any,
+        response: Any,
+        parsed: Any,
+        finding: Any,
+    ) -> None:
+        manifest = ctx.manifest
+        artifact_rel = self._artifact_rel(manifest.job_id, page_number)
+        artifact = {
+            "schema_version": CURRENT_SCHEMA_VERSION,
+            "kind": "page_artifact",
+            "document_id": manifest.document_id,
+            "page_number": page_number,
+            "page_id": request.page_id,
+            "markdown": parsed.markdown,
+            "result_pointer": str(artifact_rel),
+            "verifier_metadata": [
+                {
+                    "accepted": finding.accepted,
+                    "kind": finding.kind,
+                    "retry_class": finding.retry_class,
+                    "warnings": list(finding.warnings),
                 }
-                with self.governor.acquire(ResourceKind.STATE_STORE):
-                    self.state.write_json_atomic(artifact_rel, artifact)
-                committed = {
-                    **attempt,
-                    "state": "succeeded",
-                    "provider_response_committed_at": float(self.clock()),
-                    "result_pointer": str(artifact_rel),
-                }
-                self._write_ledger(manifest.job_id, attempt_id, committed)
-                pages[page_key] = {
-                    **pages[page_key],
-                    "state": "succeeded",
-                    "artifact_path": str(artifact_rel),
-                    "fingerprint": request.fingerprint,
-                }
-                self._write_indexes(manifest, pages, partial=False)
-                return _PageOutcome("succeeded")
+            ],
+            "fingerprint": request.fingerprint,
+            "image_hash": request.image_hash,
+            "provider_request_id": response.provider_request_id,
+            "provider_metadata": response.metadata,
+            "profile_metadata": parsed.metadata,
+        }
+        # Write the durable truth (artifact + ledger), fsync'd, before the index event.
+        with governor.acquire(ResourceKind.STATE_STORE):
+            await asyncio.to_thread(self.state.write_json_atomic, artifact_rel, artifact)
+        committed = {
+            **attempt,
+            "state": "succeeded",
+            "provider_response_committed_at": float(self.clock()),
+            "result_pointer": str(artifact_rel),
+        }
+        await self._awrite_ledger(governor, manifest.job_id, attempt_id, committed)
+        await ctx.writer.publish(
+            page_number,
+            {**reserved_entry, "state": "succeeded", "artifact_path": str(artifact_rel)},
+            notable=False,
+        )
 
-    def _fail_attempt(self, manifest: JobManifest, pages: Json, page_number: int, attempt: Json, *, state: str, diagnostic: str) -> None:
-        failed = {**attempt, "state": state, "diagnostic": diagnostic}
-        self._write_ledger(manifest.job_id, str(attempt["attempt_id"]), failed)
-        pages[str(page_number)] = {**pages[str(page_number)], "state": state, "diagnostic": diagnostic}
-        self._write_indexes(manifest, pages, partial=False)
+    async def _maybe_commit_blank(
+        self,
+        ctx: "_RunContext",
+        governor: ResourceGovernor,
+        page_number: int,
+        attempt_id: str,
+        attempt: Json,
+        reserved_entry: Json,
+        request: Any,
+        response: Any,
+        *,
+        diagnostic: str,
+        image_bytes: bytes,
+    ) -> "_AttemptResult | None":
+        """Accept a genuinely-blank page as a successful empty artifact, or return None.
+
+        Triggers only when the render is near-blank (the ink gate) AND the OCR produced
+        no readable content — either empty output or a degenerate repetition loop, both
+        of which a VLM emits on a blank/noise page. The ink gate protects real content
+        pages (ink above threshold), which never reach here and remediate normally.
+        """
+        if diagnostic not in _BLANK_ELIGIBLE_DIAGNOSTICS or not _render_is_blank(image_bytes):
+            return None
+        from paperscale.profiles.base import ProfileValidationResult
+        from paperscale.quality.verifier import VerificationFinding
+
+        parsed = ProfileValidationResult(ok=True, markdown="", metadata={"blank_page": True})
+        finding = VerificationFinding(True, "blank_page", "none", [])
+        await self._commit_success(
+            ctx, governor, page_number, attempt_id, attempt, reserved_entry, request, response, parsed, finding
+        )
+        ctx.overload.record_success()
+        await ctx.limiter.set_limit(ctx.overload.concurrency_limit)
+        return _AttemptResult("succeeded", "blank_page", False, 0.0)
+
+    async def _demote_terminal(self, ctx: "_RunContext", page_number: int, accumulated: dict[str, Any]) -> None:
+        diagnostic = f"exhausted {self.config.max_attempts} attempts"
+        entry = dict(ctx.pages[str(page_number)])
+        entry.update({"state": "failed_terminal", "diagnostic": diagnostic, "overrides": accumulated})
+        await ctx.writer.publish(page_number, entry, notable=True)
+
+    async def _awrite_ledger(self, governor: ResourceGovernor, job_id: str, attempt_id: str, payload: Json) -> None:
+        with governor.acquire(ResourceKind.STATE_STORE):
+            await asyncio.to_thread(self.state.write_json_atomic, self._ledger_rel(job_id, attempt_id), payload)
+
+    async def _send(self, provider: Any, request: Any) -> Any:
+        send = provider.send
+        if inspect.iscoroutinefunction(send):
+            return await send(request)
+        result = await asyncio.to_thread(send, request)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    async def _maybe_sleep(self, seconds: float) -> None:
+        result = self._sleep(seconds)
+        if inspect.isawaitable(result):
+            await result
 
     def _assemble_if_ready(self, manifest: JobManifest, pages: Json, *, allow_partial: bool) -> None:
         succeeded_pages = [int(page) for page, entry in pages.items() if isinstance(entry, dict) and entry.get("state") == "succeeded"]
@@ -605,18 +1132,69 @@ class DocumentOcrRunner:
             ensure_known_schema(attempt)
             if float(attempt.get("lease_expires_at", now + 1)) > now:
                 continue
+            if attempt.get("state") not in {"reserved", "in_flight"}:
+                continue
+
+            # Adopt-then-requeue: the crash window is most likely *after* the artifact
+            # is durably written but *before* the index recorded success. If the
+            # artifact exists and its fingerprint matches this attempt's fingerprint,
+            # adopt it (zero provider calls) rather than re-calling.
+            page_number = int(page_text)
+            adopted = self._adopt_if_artifact_matches(manifest, attempt, page_number)
+            if adopted is not None:
+                self._write_ledger(
+                    manifest.job_id, attempt_id,
+                    {**attempt, "state": "succeeded", "result_pointer": adopted["artifact_path"]},
+                )
+                pages[page_text] = adopted
+                changed = True
+                continue
+
+            # No adoptable artifact. Auto-requeue by default; only a metered endpoint
+            # (billable / non-idempotent) escalates a crashed in_flight to ambiguous.
             if attempt.get("state") == "reserved" and attempt.get("provider_started_at") is None:
                 new_state = "pending"
-            elif attempt.get("state") == "in_flight" and attempt.get("result_pointer") is None:
-                new_state = "ambiguous"
+            elif attempt.get("state") == "in_flight":
+                new_state = "ambiguous" if self.config.metered else "pending"
             else:
-                continue
-            attempt = {**attempt, "state": new_state, "duplicate_call_risk": new_state == "ambiguous"}
+                new_state = "pending"
+            duplicate_call_risk = new_state == "ambiguous"
+            attempt = {**attempt, "state": new_state, "duplicate_call_risk": duplicate_call_risk}
             self._write_ledger(manifest.job_id, attempt_id, attempt)
-            pages[page_text] = {**entry, "state": new_state, "duplicate_call_risk": new_state == "ambiguous"}
+            requeued = {
+                "state": new_state,
+                "epoch": int(entry.get("epoch") or attempt.get("epoch") or 0),
+                "attempt_id": None if new_state == "pending" else attempt_id,
+                "fingerprint": None if new_state == "pending" else entry.get("fingerprint"),
+                "duplicate_call_risk": duplicate_call_risk,
+            }
+            if entry.get("overrides"):
+                requeued["overrides"] = entry["overrides"]
+            pages[page_text] = requeued
             changed = True
         if changed:
+            self._assemble_if_ready(manifest, pages, allow_partial=False)
             self._write_indexes(manifest, pages, partial=False)
+
+    def _adopt_if_artifact_matches(self, manifest: JobManifest, attempt: Json, page_number: int) -> Json | None:
+        """Return a succeeded page entry if a fingerprint-matching artifact exists.
+
+        The fingerprint match proves the artifact came from *this* attempt's exact
+        request (not a stale/superseded epoch). Mirrors ``repair_index`` adoption.
+        """
+        artifact_rel = self._artifact_rel(manifest.job_id, page_number)
+        if not (self.state.root / artifact_rel).exists():
+            return None
+        artifact = self.state.read_json(artifact_rel)
+        ensure_known_schema(artifact)
+        if artifact.get("fingerprint") != attempt.get("fingerprint"):
+            return None
+        return {
+            "state": "succeeded",
+            "artifact_path": str(artifact_rel),
+            "fingerprint": artifact.get("fingerprint"),
+            "epoch": int(attempt.get("epoch") or 0),
+        }
 
     def _write_manifest(self, manifest: JobManifest) -> None:
         with self.governor.acquire(ResourceKind.STATE_STORE):
@@ -644,7 +1222,15 @@ class DocumentOcrRunner:
             raise CompactIndexError(f"missing pages in status index for {job_id}")
         return {str(key): dict(value) for key, value in pages.items() if isinstance(value, dict)}
 
-    def _write_indexes(self, manifest: JobManifest, pages: Json, *, partial: bool) -> JobStatus:
+    def _write_indexes(
+        self,
+        manifest: JobManifest,
+        pages: Json,
+        *,
+        partial: bool,
+        fsync: bool = True,
+        governor: ResourceGovernor | None = None,
+    ) -> JobStatus:
         counts = _count_states(pages)
         status_index: Json = {
             "schema_version": CURRENT_SCHEMA_VERSION,
@@ -684,10 +1270,11 @@ class DocumentOcrRunner:
                 if isinstance(entry, dict) and entry.get("state") == "ambiguous"
             ],
         }
-        with self.governor.acquire(ResourceKind.STATE_STORE):
-            self.state.write_json_atomic(self._index_rel(manifest.job_id, "status"), status_index)
-            self.state.write_json_atomic(self._index_rel(manifest.job_id, "resume"), resume_index)
-            self.state.write_json_atomic(self._index_rel(manifest.job_id, "reconcile"), reconcile_index)
+        gov = governor or self.governor
+        with gov.acquire(ResourceKind.STATE_STORE):
+            self.state.write_json_atomic(self._index_rel(manifest.job_id, "status"), status_index, fsync=fsync)
+            self.state.write_json_atomic(self._index_rel(manifest.job_id, "resume"), resume_index, fsync=fsync)
+            self.state.write_json_atomic(self._index_rel(manifest.job_id, "reconcile"), reconcile_index, fsync=fsync)
         return JobStatus.from_index(status_index)
 
     def _write_ledger(self, job_id: str, attempt_id: str, payload: Json) -> None:
@@ -746,12 +1333,6 @@ class _HttpResponse:
 
     def json(self) -> Any:
         return self._payload
-
-
-def _default_provider(base_url: str) -> OpenAIChatProvider:
-    from openai import OpenAI
-
-    return OpenAIChatProvider(client=OpenAI(base_url=_normalize_openai_base_url(base_url), api_key="paperscale-local"))
 
 
 def _normalize_openai_base_url(base_url: str) -> str:

--- a/src/paperscale/state/claim_store.py
+++ b/src/paperscale/state/claim_store.py
@@ -1,0 +1,233 @@
+"""Single-machine, multi-process document claim tier.
+
+Scope is always a single machine with multiple ``paperscale`` processes pulling
+work; no cross-machine / NFS / object-store backends (explicitly YAGNI). The unit
+of claim is the document/job, so the entire intra-process design (single index
+writer, async pool, backpressure) runs unchanged within a claim.
+
+Substrate: an ``O_EXCL`` filesystem claim record ``jobs/<job_id>/claim.json``,
+atomic on a local fs, carrying ``worker_id``/``epoch``/``lease_expires_at``/
+``heartbeat_at``. Correctness does NOT rest on the lock: a paused owner can wake
+after takeover and still write, and a dumb filesystem cannot fence that write.
+Safety rests instead on (1) page-keyed deterministic artifacts (a zombie write is
+redundant, not corrupting) and (2) epoch-aware reconcile (the index writer/recovery
+ignores attempts from a superseded epoch). A brief two-owner overlap therefore only
+yields a stale index the higher-epoch owner overwrites and resume reconciles.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Callable
+
+from paperscale.contracts import CURRENT_SCHEMA_VERSION, ensure_known_schema
+
+
+@dataclass(frozen=True, slots=True)
+class Claim:
+    job_id: str
+    worker_id: str
+    epoch: int
+    lease_expires_at: float
+    heartbeat_at: float
+
+
+class ClaimStore:
+    """O_EXCL document claims with leases, heartbeats, and epoch reclaim."""
+
+    def __init__(
+        self,
+        root: Path | str,
+        *,
+        worker_id: str,
+        clock: Callable[[], float],
+        lease_seconds: float = 60.0,
+        heartbeat_seconds: float = 20.0,
+    ) -> None:
+        self.root = Path(root)
+        self.worker_id = worker_id
+        self._clock = clock
+        self.lease_seconds = lease_seconds
+        self.heartbeat_seconds = heartbeat_seconds
+
+    # -- paths -------------------------------------------------------------
+    def _job_dir(self, job_id: str) -> Path:
+        return self.root / "jobs" / job_id
+
+    def _claim_path(self, job_id: str) -> Path:
+        return self._job_dir(job_id) / "claim.json"
+
+    def _done_path(self, job_id: str) -> Path:
+        return self._job_dir(job_id) / "done.json"
+
+    # -- done marker (durable truth) --------------------------------------
+    def is_done(self, job_id: str) -> bool:
+        return self._done_path(job_id).exists()
+
+    def mark_done(self, job_id: str) -> None:
+        """Write a durable, fsync'd ``done`` marker on true completion.
+
+        Truth, unlike the eventually-consistent index. The claim path checks the
+        marker before attempting a claim, so finished documents are skipped.
+        """
+        payload = {
+            "schema_version": CURRENT_SCHEMA_VERSION,
+            "kind": "job_done_marker",
+            "job_id": job_id,
+            "worker_id": self.worker_id,
+            "completed_at": float(self._clock()),
+        }
+        _write_json_fsync(self._done_path(job_id), payload)
+
+    # -- claim lifecycle ---------------------------------------------------
+    def try_claim(self, job_id: str, *, skip_if_done: bool = True) -> Claim | None:
+        """Attempt to claim ``job_id``; return a ``Claim`` or ``None`` if unavailable.
+
+        Returns ``None`` when held by a live owner (any process), or when the job is
+        already done and ``skip_if_done`` is set. The auto-scanning ``work`` loop uses
+        ``skip_if_done=True`` to skip finished jobs; an operator-initiated
+        ``run``/``resume`` passes ``skip_if_done=False`` so a stale done marker never
+        blocks an explicit re-run. Reclaims an expired lease at a strictly higher epoch.
+        """
+        if skip_if_done and self.is_done(job_id):
+            return None
+        self._job_dir(job_id).mkdir(parents=True, exist_ok=True)
+        now = float(self._clock())
+
+        # Fast path: nobody holds the claim -> atomic exclusive create.
+        created = self._exclusive_create(job_id, epoch=1, now=now)
+        if created is not None:
+            return created
+
+        # Contended: read the incumbent. Skip if its lease is still live.
+        incumbent = self._read_claim(job_id)
+        if incumbent is None:
+            # File appeared/vanished mid-race; one more exclusive attempt.
+            return self._exclusive_create(job_id, epoch=1, now=now)
+        if incumbent.lease_expires_at > now:
+            return None
+        # Expired lease: reclaim at a higher epoch (last-write-wins on a dumb fs;
+        # the read-side epoch fence makes the brief overlap safe).
+        return self._overwrite_claim(job_id, epoch=incumbent.epoch + 1, now=now)
+
+    def heartbeat(self, claim: Claim) -> Claim:
+        now = float(self._clock())
+        return self._overwrite_claim(claim.job_id, epoch=claim.epoch, now=now)
+
+    def release(self, claim: Claim) -> None:
+        """Drop our claim so another process may take the job.
+
+        Only removes the record if we still own it (epoch + worker match), so a
+        late release after takeover does not evict the new owner.
+        """
+        current = self._read_claim(claim.job_id)
+        if current is None:
+            return
+        if current.worker_id == claim.worker_id and current.epoch == claim.epoch:
+            try:
+                self._claim_path(claim.job_id).unlink()
+            except FileNotFoundError:
+                pass
+
+    # -- internals ---------------------------------------------------------
+    def _exclusive_create(self, job_id: str, *, epoch: int, now: float) -> Claim | None:
+        claim = Claim(
+            job_id=job_id,
+            worker_id=self.worker_id,
+            epoch=epoch,
+            lease_expires_at=now + self.lease_seconds,
+            heartbeat_at=now,
+        )
+        path = self._claim_path(job_id)
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            return None
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(_claim_payload(claim), handle, sort_keys=True, separators=(",", ":"))
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        except BaseException:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            raise
+        return claim
+
+    def _overwrite_claim(self, job_id: str, *, epoch: int, now: float) -> Claim:
+        claim = Claim(
+            job_id=job_id,
+            worker_id=self.worker_id,
+            epoch=epoch,
+            lease_expires_at=now + self.lease_seconds,
+            heartbeat_at=now,
+        )
+        _write_json_fsync(self._claim_path(job_id), _claim_payload(claim))
+        return claim
+
+    def _read_claim(self, job_id: str) -> Claim | None:
+        path = self._claim_path(job_id)
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+        ensure_known_schema(payload)
+        try:
+            return Claim(
+                job_id=str(payload["job_id"]),
+                worker_id=str(payload["worker_id"]),
+                epoch=int(payload["epoch"]),
+                lease_expires_at=float(payload["lease_expires_at"]),
+                heartbeat_at=float(payload["heartbeat_at"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+
+def _claim_payload(claim: Claim) -> dict[str, object]:
+    return {
+        "schema_version": CURRENT_SCHEMA_VERSION,
+        "kind": "job_claim",
+        "job_id": claim.job_id,
+        "worker_id": claim.worker_id,
+        "epoch": claim.epoch,
+        "lease_expires_at": claim.lease_expires_at,
+        "heartbeat_at": claim.heartbeat_at,
+    }
+
+
+def _write_json_fsync(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        _fsync_dir(path.parent)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _fsync_dir(directory: Path) -> None:
+    try:
+        fd = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)

--- a/src/paperscale/state/fs_store.py
+++ b/src/paperscale/state/fs_store.py
@@ -18,7 +18,23 @@ class FileSystemStateStore:
         self.root.mkdir(parents=True, exist_ok=True)
         self.debug_tree_scan_count = 0
 
-    def write_json_atomic(self, relative_path: str | Path, payload: dict[str, Any], *, crash_hook: Any | None = None) -> Path:
+    def write_json_atomic(
+        self,
+        relative_path: str | Path,
+        payload: dict[str, Any],
+        *,
+        crash_hook: Any | None = None,
+        fsync: bool = True,
+    ) -> Path:
+        """Atomically write JSON via temp-file + ``os.replace``.
+
+        ``fsync=True`` (default) durably persists the bytes and the rename — use it
+        for the *truth* (artifacts, ledger, claim/done markers). ``fsync=False`` is
+        atomic (no torn reads) but not durable — use it only for the derived,
+        rebuildable compact indexes, where losing the last write on power loss is
+        harmless because resume reconciles from the truth.
+        """
+
         target = self.root / relative_path
         target.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=target.parent)
@@ -27,11 +43,13 @@ class FileSystemStateStore:
                 json.dump(payload, file, sort_keys=True, separators=(",", ":"))
                 file.write("\n")
                 file.flush()
-                os.fsync(file.fileno())
+                if fsync:
+                    os.fsync(file.fileno())
             if crash_hook is not None:
                 crash_hook.checkpoint("after_temp_fsync_before_replace")
             os.replace(tmp, target)
-            self._fsync_dir(target.parent)
+            if fsync:
+                self._fsync_dir(target.parent)
         except BaseException:
             try:
                 os.unlink(tmp)

--- a/tests/profiles/test_builtin_profiles.py
+++ b/tests/profiles/test_builtin_profiles.py
@@ -15,7 +15,7 @@ class BuiltinProfileTests(unittest.TestCase):
             self.assertEqual(profile.task, "document_to_markdown")
             self.assertNotIn("free_ocr", profile.public_modes)
             self.assertNotIn("visual_qa", profile.public_modes)
-            self.assertIn("Markdown", profile.prompt_template)
+            self.assertIn("markdown", profile.prompt_template.lower())
 
     def test_first_class_profiles_build_provider_neutral_requests_from_same_page_input(self) -> None:
         for name in ("lighton_ocr_2_1b", "deepseek_ocr_2", "glm_ocr"):

--- a/tests/profiles/test_remediation.py
+++ b/tests/profiles/test_remediation.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import unittest
+
+from paperscale.profiles.builtin import get_builtin_profile
+
+
+class RemediationLadderTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # deepseek_ocr_2 has the richest base decoding/render options.
+        self.profile = get_builtin_profile("deepseek_ocr_2")
+        self.base_tokens = int(self.profile.decoding["max_tokens"])
+        self.base_side = int(self.profile.render_options["target_longest_side"])
+
+    def test_unknown_diagnostic_is_identity(self) -> None:
+        acc = self.profile.remediation_for("totally_unknown", accumulated=None)
+        applied = self.profile.with_overrides(
+            decoding=acc.get("decoding"), render_options=acc.get("render_options")
+        )
+        self.assertEqual(applied.decoding["max_tokens"], self.base_tokens)
+        self.assertEqual(applied.render_options["target_longest_side"], self.base_side)
+
+    def test_truncation_increases_token_budget(self) -> None:
+        acc = self.profile.remediation_for("truncation_indicator", accumulated=None)
+        self.assertGreater(acc["decoding"]["max_tokens"], self.base_tokens)
+
+    def test_length_anomaly_increases_token_budget(self) -> None:
+        acc = self.profile.remediation_for("length_anomaly", accumulated=None)
+        self.assertGreater(acc["decoding"]["max_tokens"], self.base_tokens)
+
+    def test_mojibake_increases_render_resolution(self) -> None:
+        acc = self.profile.remediation_for("mojibake", accumulated=None)
+        self.assertGreater(acc["render_options"]["target_longest_side"], self.base_side)
+
+    def test_control_characters_increase_render_resolution(self) -> None:
+        acc = self.profile.remediation_for("control_characters", accumulated=None)
+        self.assertGreater(acc["render_options"]["target_longest_side"], self.base_side)
+
+    def test_repeated_ngram_raises_repetition_penalty(self) -> None:
+        acc = self.profile.remediation_for("repeated_ngram", accumulated=None)
+        self.assertGreater(acc["decoding"].get("repetition_penalty", 1.0), 1.0)
+
+    def test_remediations_accumulate_across_dimensions(self) -> None:
+        # A mojibake DPI bump must survive a subsequent truncation token bump.
+        acc = self.profile.remediation_for("mojibake", accumulated=None)
+        acc = self.profile.remediation_for("truncation_indicator", accumulated=acc)
+        self.assertGreater(acc["render_options"]["target_longest_side"], self.base_side)
+        self.assertGreater(acc["decoding"]["max_tokens"], self.base_tokens)
+
+    def test_repeated_application_monotonic_then_caps_at_ceiling(self) -> None:
+        acc = None
+        seen: list[int] = []
+        for _ in range(12):
+            acc = self.profile.remediation_for("truncation_indicator", accumulated=acc)
+            seen.append(acc["decoding"]["max_tokens"])
+        # monotonically non-decreasing
+        self.assertEqual(seen, sorted(seen))
+        # never exceeds the profile's declared ceiling
+        self.assertLessEqual(max(seen), self.profile.max_decode_tokens)
+        # actually reaches the ceiling under sustained pressure
+        self.assertEqual(seen[-1], self.profile.max_decode_tokens)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/providers/test_aimd.py
+++ b/tests/providers/test_aimd.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import unittest
+
+from paperscale.providers.self_hosted import ProviderCapacityProfile, ProviderOverloadController
+
+
+def _capacity(max_in_flight: int) -> ProviderCapacityProfile:
+    return ProviderCapacityProfile(
+        name="aimd",
+        max_in_flight_requests=max_in_flight,
+        max_provider_queue=max_in_flight * 2,
+        queue_size=max_in_flight * 2,
+        timeout_seconds=10.0,
+        backoff_initial_seconds=0.5,
+        backoff_max_seconds=8.0,
+        circuit_breaker_failure_threshold=100,  # keep circuit out of the way
+        circuit_breaker_cooldown_seconds=10.0,
+        render_target_longest_side=800,
+    )
+
+
+class AimdConcurrencyTests(unittest.TestCase):
+    def test_starts_fed_at_ceiling(self) -> None:
+        controller = ProviderOverloadController(_capacity(16), floor=4, ceiling=16)
+        self.assertEqual(controller.concurrency_limit, 16)
+
+    def test_overload_multiplicatively_decreases_toward_floor(self) -> None:
+        controller = ProviderOverloadController(_capacity(16), floor=4, ceiling=16, decrease_factor=0.5)
+        controller.record_status(429)
+        self.assertEqual(controller.concurrency_limit, 8)
+        controller.record_status(503)
+        self.assertEqual(controller.concurrency_limit, 4)
+        controller.record_status(500)  # already at floor; never drops below
+        self.assertEqual(controller.concurrency_limit, 4)
+
+    def test_transport_failure_also_shrinks(self) -> None:
+        controller = ProviderOverloadController(_capacity(16), floor=4, ceiling=16, decrease_factor=0.5)
+        controller.record_failure(retryable=True)
+        self.assertEqual(controller.concurrency_limit, 8)
+
+    def test_sustained_success_additively_increases_toward_ceiling(self) -> None:
+        controller = ProviderOverloadController(
+            _capacity(16), floor=4, ceiling=16, decrease_factor=0.5, success_threshold=3, additive_step=1
+        )
+        controller.record_status(429)  # 16 -> 8
+        controller.record_status(429)  # 8 -> 4
+        self.assertEqual(controller.concurrency_limit, 4)
+        # additive increase only after sustained success
+        for _ in range(3):
+            controller.record_success()
+        self.assertEqual(controller.concurrency_limit, 5)
+        for _ in range(3):
+            controller.record_success()
+        self.assertEqual(controller.concurrency_limit, 6)
+
+    def test_never_exceeds_ceiling(self) -> None:
+        controller = ProviderOverloadController(
+            _capacity(8), floor=2, ceiling=8, success_threshold=1, additive_step=4
+        )
+        for _ in range(20):
+            controller.record_success()
+        self.assertEqual(controller.concurrency_limit, 8)
+
+    def test_content_failure_never_throttles(self) -> None:
+        controller = ProviderOverloadController(_capacity(16), floor=4, ceiling=16)
+        controller.note_content_failure()
+        controller.note_content_failure()
+        self.assertEqual(controller.concurrency_limit, 16)
+        self.assertFalse(controller.circuit_open)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/providers/test_self_hosted.py
+++ b/tests/providers/test_self_hosted.py
@@ -123,5 +123,53 @@ class SelfHostedProviderProfileTests(unittest.TestCase):
         self.assertEqual(controller.queued_requests, 2)
 
 
+def _capacity(threshold: int = 3, *, initial: float = 1.0, maximum: float = 8.0):
+    from paperscale.providers.self_hosted import ProviderCapacityProfile
+
+    return ProviderCapacityProfile(
+        name="test",
+        max_in_flight_requests=1,
+        max_provider_queue=1,
+        queue_size=1,
+        timeout_seconds=1.0,
+        backoff_initial_seconds=initial,
+        backoff_max_seconds=maximum,
+        circuit_breaker_failure_threshold=threshold,
+        circuit_breaker_cooldown_seconds=1.0,
+        render_target_longest_side=10,
+    )
+
+
+class RecordFailureTests(unittest.TestCase):
+    def test_retryable_failures_open_circuit_after_threshold(self) -> None:
+        from paperscale.providers.self_hosted import ProviderOverloadController
+
+        controller = ProviderOverloadController(_capacity(threshold=3))
+        first = controller.record_failure(retryable=True)
+        second = controller.record_failure(retryable=True)
+        third = controller.record_failure(retryable=True)
+        self.assertTrue(first.should_retry)
+        self.assertFalse(first.circuit_open)
+        self.assertTrue(second.should_retry)
+        self.assertTrue(third.circuit_open)
+        self.assertFalse(third.should_retry)
+
+    def test_backoff_grows_exponentially_then_caps(self) -> None:
+        from paperscale.providers.self_hosted import ProviderOverloadController
+
+        controller = ProviderOverloadController(_capacity(threshold=10, initial=1.0, maximum=8.0))
+        backoffs = [controller.record_failure(retryable=True).backoff_seconds for _ in range(5)]
+        self.assertEqual(backoffs, [1.0, 2.0, 4.0, 8.0, 8.0])
+
+    def test_non_retryable_failure_resets_consecutive_count(self) -> None:
+        from paperscale.providers.self_hosted import ProviderOverloadController
+
+        controller = ProviderOverloadController(_capacity(threshold=2))
+        controller.record_failure(retryable=True)
+        decision = controller.record_failure(retryable=False)
+        self.assertFalse(decision.should_retry)
+        self.assertFalse(controller.circuit_open)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/state/test_claim_store.py
+++ b/tests/state/test_claim_store.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from paperscale.state.claim_store import ClaimStore
+
+
+class ClaimStoreTests(unittest.TestCase):
+    def _store(self, root: Path, now_box: list[float], worker: str) -> ClaimStore:
+        return ClaimStore(
+            root,
+            worker_id=worker,
+            clock=lambda: now_box[0],
+            lease_seconds=60.0,
+            heartbeat_seconds=20.0,
+        )
+
+    def test_fresh_claim_succeeds_and_held_claim_blocks_other_process(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = [100.0]
+            a = self._store(root, now, "worker-a")
+            b = self._store(root, now, "worker-b")
+
+            claim = a.try_claim("job-1")
+            self.assertIsNotNone(claim)
+            self.assertEqual(claim.worker_id, "worker-a")
+            # b cannot co-own a fresh, unexpired claim (O_EXCL exclusivity).
+            self.assertIsNone(b.try_claim("job-1"))
+
+    def test_done_marker_skips_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = [100.0]
+            a = self._store(root, now, "worker-a")
+            self.assertFalse(a.is_done("job-2"))
+            a.mark_done("job-2")
+            self.assertTrue(a.is_done("job-2"))
+            self.assertIsNone(a.try_claim("job-2"))
+
+    def test_expired_lease_is_reclaimed_with_higher_epoch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = [100.0]
+            a = self._store(root, now, "worker-a")
+            b = self._store(root, now, "worker-b")
+
+            first = a.try_claim("job-3")
+            self.assertEqual(first.epoch, 1)
+            # a goes silent; lease expires.
+            now[0] = 200.0
+            reclaimed = b.try_claim("job-3")
+            self.assertIsNotNone(reclaimed)
+            self.assertEqual(reclaimed.worker_id, "worker-b")
+            self.assertGreater(reclaimed.epoch, first.epoch)
+
+    def test_heartbeat_extends_lease_and_prevents_takeover(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = [100.0]
+            a = self._store(root, now, "worker-a")
+            b = self._store(root, now, "worker-b")
+
+            claim = a.try_claim("job-4")
+            now[0] = 150.0
+            a.heartbeat(claim)  # extends lease to 150+60=210
+            now[0] = 200.0
+            self.assertIsNone(b.try_claim("job-4"))
+
+    def test_release_allows_reclaim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = [100.0]
+            a = self._store(root, now, "worker-a")
+            b = self._store(root, now, "worker-b")
+
+            claim = a.try_claim("job-5")
+            a.release(claim)
+            again = b.try_claim("job-5")
+            self.assertIsNotNone(again)
+            self.assertEqual(again.worker_id, "worker-b")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_concurrency_pool.py
+++ b/tests/test_concurrency_pool.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import threading
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from paperscale.providers.base import PageOcrResponse, ProviderError
+from paperscale.runner import DocumentOcrRunner, RunnerConfig
+
+
+@dataclass(frozen=True)
+class _Rendered:
+    page_number: int
+    image_bytes: bytes
+    image_hash: str
+    media_type: str = "image/png"
+
+
+class _Renderer:
+    def __init__(self, n: int) -> None:
+        self._n = n
+
+    @property
+    def page_count(self) -> int:
+        return self._n
+
+    def render_page(self, page_number: int) -> _Rendered:
+        image = f"page-{page_number}".encode()
+        return _Rendered(page_number, image, hashlib.sha256(image).hexdigest())
+
+
+class _GoodProvider:
+    name = "good"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.max_concurrent = 0
+        self._active = 0
+        self.calls = 0
+
+    def send(self, request: Any) -> PageOcrResponse:
+        with self._lock:
+            self._active += 1
+            self.max_concurrent = max(self.max_concurrent, self._active)
+            self.calls += 1
+        try:
+            return PageOcrResponse(markdown=f"# {request.page_id}\n\nBody for {request.page_id}.", provider_request_id=request.fingerprint)
+        finally:
+            with self._lock:
+                self._active -= 1
+
+
+class _AlwaysFail:
+    name = "fail"
+
+    def send(self, request: Any) -> PageOcrResponse:
+        raise ProviderError("down")
+
+
+class ConcurrencyPoolTests(unittest.TestCase):
+    def test_many_pages_all_succeed_and_index_is_consistent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".paperscale"
+            provider = _GoodProvider()
+            runner = DocumentOcrRunner(
+                RunnerConfig(state_root=root, base_url="http://fake/v1", model="m", max_in_flight_requests=8, server_max_num_seqs=8),
+                provider=provider,
+                renderer_factory=lambda _p, _o: _Renderer(40),
+                sleeper=lambda _s: None,
+            )
+            status = runner.run(input_path=root / "i.pdf", output_path=root / "o.md", job_id="big")
+            self.assertEqual(status.succeeded, 40)
+            self.assertTrue(status.complete)
+            self.assertEqual(provider.calls, 40)  # each page sent exactly once
+            # The single index writer folded every event into a consistent rollup.
+            idx = json.loads((root / "jobs" / "big" / "indexes" / "status.json").read_text())
+            self.assertEqual(idx["succeeded"], 40)
+            self.assertEqual(sum(1 for p in idx["pages"].values() if p["state"] == "succeeded"), 40)
+
+    def test_in_flight_semaphore_bounds_concurrency(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".paperscale"
+            provider = _GoodProvider()
+            runner = DocumentOcrRunner(
+                RunnerConfig(state_root=root, base_url="http://fake/v1", model="m", max_in_flight_requests=3),
+                provider=provider,
+                renderer_factory=lambda _p, _o: _Renderer(30),
+                sleeper=lambda _s: None,
+            )
+            runner.run(input_path=root / "i.pdf", output_path=root / "o.md", job_id="bounded")
+            # Never more than max_in_flight_requests concurrent provider calls.
+            self.assertLessEqual(provider.max_concurrent, 3)
+
+
+class WorkClaimTests(unittest.TestCase):
+    def test_work_resumes_incomplete_job_then_skips_completed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".paperscale"
+            # First pass: the server is down, circuit opens, job left incomplete.
+            failing = DocumentOcrRunner(
+                RunnerConfig(state_root=root, base_url="http://fake/v1", model="m", max_in_flight_requests=1),
+                provider=_AlwaysFail(),
+                renderer_factory=lambda _p, _o: _Renderer(2),
+                sleeper=lambda _s: None,
+            )
+            first = failing.run(input_path=root / "i.pdf", output_path=root / "o.md", job_id="wjob", allow_partial=True)
+            self.assertFalse(first.complete)
+
+            # A worker process with a healthy provider claims and finishes it.
+            worker = DocumentOcrRunner(
+                RunnerConfig(state_root=root, base_url="http://fake/v1", model="m", worker_id="worker-2", max_in_flight_requests=4),
+                provider=_GoodProvider(),
+                renderer_factory=lambda _p, _o: _Renderer(2),
+                sleeper=lambda _s: None,
+            )
+            results = worker.work()
+            self.assertEqual(len(results), 1)
+            self.assertTrue(results[0].complete)
+            self.assertTrue((root / "jobs" / "wjob" / "done.json").exists())
+
+            # A subsequent worker skips the done job (no claimable work).
+            self.assertEqual(worker.work(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fsck_and_reconcile.py
+++ b/tests/test_fsck_and_reconcile.py
@@ -208,12 +208,40 @@ class ReconcileSupersedeTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 runner.resolve_ambiguous("job", 1, action="supersede")
 
-    def test_recovery_marks_inflight_ambiguous_with_recommended_actions(self) -> None:
+    def test_recovery_adopts_matching_artifact_without_provider_call(self) -> None:
+        # Adopt-then-requeue: a crashed in_flight page whose durable artifact exists
+        # and whose fingerprint matches the attempt is adopted as succeeded on resume,
+        # with zero provider calls (the default, non-metered behavior).
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            attempt_id = _make_page_inflight_expired(job_dir, 2)
+            # Keep the attempt fingerprint in sync with the surviving artifact so the
+            # adoption fingerprint-match holds.
+            artifact = json.loads((job_dir / "artifacts" / "pages" / "2.json").read_text(encoding="utf-8"))
+            attempt_path = job_dir / "ledger" / f"{attempt_id}.json"
+            attempt = json.loads(attempt_path.read_text(encoding="utf-8"))
+            attempt["fingerprint"] = artifact["fingerprint"]
+            attempt_path.write_text(json.dumps(attempt, sort_keys=True), encoding="utf-8")
+            # No provider responses left: any re-call would raise, proving none happens.
+            runner.provider = _OkProvider([])
+
+            status = runner.resume("job", allow_partial=True)
+
+            self.assertTrue(status.complete)
+            self.assertEqual(_read_status(job_dir)["pages"]["2"]["state"], "succeeded")
+            self.assertEqual(runner.reconcile("job")["ambiguous_attempts"], [])
+
+    def test_metered_recovery_marks_inflight_ambiguous_when_no_artifact(self) -> None:
+        # The ambiguous/reconcile machinery is retained but opt-in for metered endpoints.
         with tempfile.TemporaryDirectory() as tmp:
             state_root = Path(tmp) / ".paperscale"
             runner = _run_job(state_root, "job", pages=2)
             job_dir = state_root / "jobs" / "job"
             _make_page_inflight_expired(job_dir, 2)
+            (job_dir / "artifacts" / "pages" / "2.json").unlink()  # no adoptable artifact
+            runner.config = RunnerConfig(state_root=state_root, base_url="http://fake/v1", model="mock-vlm", metered=True)
 
             runner.resume("job", allow_partial=True)
             payload = runner.reconcile("job")

--- a/tests/test_fsck_and_reconcile.py
+++ b/tests/test_fsck_and_reconcile.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import contextlib
+import json
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from paperscale.providers.base import PageOcrResponse
+from paperscale.runner import DocumentOcrRunner, RunnerConfig
+
+
+@dataclass(frozen=True)
+class _FakeRenderedPage:
+    page_number: int
+    image_bytes: bytes
+    image_hash: str
+    media_type: str = "image/png"
+
+
+class _FakeRenderer:
+    def __init__(self, pages: list[bytes]) -> None:
+        self._pages = pages
+
+    @property
+    def page_count(self) -> int:
+        return len(self._pages)
+
+    def render_page(self, page_number: int) -> _FakeRenderedPage:
+        image = self._pages[page_number - 1]
+        return _FakeRenderedPage(page_number, image, hashlib.sha256(image).hexdigest())
+
+
+class _OkProvider:
+    name = "ok-provider"
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+
+    def send(self, request: Any) -> PageOcrResponse:
+        return PageOcrResponse(markdown=self._responses.pop(0), provider_request_id=request.fingerprint)
+
+
+def _run_job(state_root: Path, job_id: str, *, pages: int = 2) -> DocumentOcrRunner:
+    runner = DocumentOcrRunner(
+        RunnerConfig(state_root=state_root, base_url="http://fake/v1", model="mock-vlm"),
+        provider=_OkProvider([f"# Page {n}\n\nBody {n}" for n in range(1, pages + 1)]),
+        renderer_factory=lambda _path, _options: _FakeRenderer([f"page-{n}".encode() for n in range(1, pages + 1)]),
+    )
+    runner.run(input_path=state_root / "in.pdf", output_path=state_root / "out.md", job_id=job_id)
+    return runner
+
+
+def _read_status(job_dir: Path) -> dict[str, Any]:
+    return json.loads((job_dir / "indexes" / "status.json").read_text(encoding="utf-8"))
+
+
+def _write_status(job_dir: Path, status: dict[str, Any]) -> None:
+    (job_dir / "indexes" / "status.json").write_text(json.dumps(status, sort_keys=True), encoding="utf-8")
+
+
+def _ledger_attempt_id_for_page(job_dir: Path, page_number: int) -> str:
+    for path in (job_dir / "ledger").glob("*.json"):
+        record = json.loads(path.read_text(encoding="utf-8"))
+        if record.get("page_number") == page_number:
+            return str(record["attempt_id"])
+    raise AssertionError(f"no ledger attempt for page {page_number}")
+
+
+def _make_page_ambiguous(job_dir: Path, page_number: int) -> str:
+    attempt_id = _ledger_attempt_id_for_page(job_dir, page_number)
+    status = _read_status(job_dir)
+    page = status["pages"][str(page_number)]
+    page.update({"state": "ambiguous", "attempt_id": attempt_id, "duplicate_call_risk": True})
+    _write_status(job_dir, status)
+    return attempt_id
+
+
+def _make_page_inflight_expired(job_dir: Path, page_number: int) -> str:
+    """Force a page back into a crashed in-flight state with an expired lease."""
+    attempt_id = _ledger_attempt_id_for_page(job_dir, page_number)
+    attempt_path = job_dir / "ledger" / f"{attempt_id}.json"
+    attempt = json.loads(attempt_path.read_text(encoding="utf-8"))
+    attempt.update({"state": "in_flight", "result_pointer": None, "provider_started_at": 1.0, "lease_expires_at": 1.0})
+    attempt_path.write_text(json.dumps(attempt, sort_keys=True), encoding="utf-8")
+    status = _read_status(job_dir)
+    status["pages"][str(page_number)] = {"state": "in_flight", "epoch": 1, "attempt_id": attempt_id}
+    _write_status(job_dir, status)
+    return attempt_id
+
+
+def _codes(report: dict[str, Any]) -> set[str]:
+    return {issue["code"] for issue in report["issues"]}
+
+
+class FsckTriangulationTests(unittest.TestCase):
+    def test_count_mismatch_when_summary_disagrees_with_pages(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            status = _read_status(job_dir)
+            status["succeeded"] = 5  # lie about the count
+            _write_status(job_dir, status)
+            report = runner.fsck("job")
+            self.assertIn("count_mismatch", _codes(report))
+
+    def test_ledger_mismatch_when_succeeded_page_has_no_terminal_attempt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            attempt_id = _ledger_attempt_id_for_page(job_dir, 2)
+            (job_dir / "ledger" / f"{attempt_id}.json").unlink()
+            report = runner.fsck("job")
+            self.assertIn("ledger_mismatch", _codes(report))
+
+    def test_fingerprint_mismatch_between_index_and_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            artifact_path = job_dir / "artifacts" / "pages" / "2.json"
+            artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+            artifact["fingerprint"] = "tampered-fingerprint"
+            artifact_path.write_text(json.dumps(artifact, sort_keys=True), encoding="utf-8")
+            report = runner.fsck("job")
+            self.assertIn("fingerprint_mismatch", _codes(report))
+
+    def test_stale_lease_for_stuck_in_flight_page(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            status = _read_status(job_dir)
+            status["pages"]["2"]["state"] = "in_flight"
+            _write_status(job_dir, status)
+            report = runner.fsck("job")
+            self.assertIn("stale_lease", _codes(report))
+
+    def test_fsck_does_not_write_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            status = _read_status(job_dir)
+            status["succeeded"] = 5
+            _write_status(job_dir, status)
+            before = (job_dir / "indexes" / "status.json").read_text(encoding="utf-8")
+            runner.fsck("job")
+            after = (job_dir / "indexes" / "status.json").read_text(encoding="utf-8")
+            self.assertEqual(before, after)
+
+
+class ReconcileSupersedeTests(unittest.TestCase):
+    def test_supersede_marks_attempt_superseded_and_requeues_page(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            attempt_id = _make_page_ambiguous(job_dir, 2)
+
+            status = runner.resolve_ambiguous("job", 2, action="supersede")
+
+            self.assertEqual(status.pending, 1)
+            self.assertEqual(status.succeeded, 1)
+            self.assertEqual(_read_status(job_dir)["pages"]["2"]["state"], "pending")
+            attempt = json.loads((job_dir / "ledger" / f"{attempt_id}.json").read_text(encoding="utf-8"))
+            self.assertEqual(attempt["state"], "superseded")
+
+    def test_accept_adopts_artifact_marks_succeeded_and_reassembles(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            attempt_id = _make_page_ambiguous(job_dir, 2)
+            (state_root / "out.md").unlink()
+
+            status = runner.resolve_ambiguous("job", 2, action="accept")
+
+            self.assertTrue(status.complete)
+            self.assertEqual(_read_status(job_dir)["pages"]["2"]["state"], "succeeded")
+            attempt = json.loads((job_dir / "ledger" / f"{attempt_id}.json").read_text(encoding="utf-8"))
+            self.assertEqual(attempt["state"], "superseded")
+            self.assertEqual(attempt["resolution"], "accepted")
+            output = (state_root / "out.md").read_text(encoding="utf-8")
+            self.assertIn("Body 1", output)
+            self.assertIn("Body 2", output)
+
+    def test_accept_without_artifact_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            _make_page_ambiguous(job_dir, 2)
+            (job_dir / "artifacts" / "pages" / "2.json").unlink()
+            with self.assertRaises(FileNotFoundError):
+                runner.resolve_ambiguous("job", 2, action="accept")
+
+    def test_resolve_rejects_non_ambiguous_page(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            with self.assertRaises(ValueError):
+                runner.resolve_ambiguous("job", 1, action="supersede")
+
+    def test_recovery_marks_inflight_ambiguous_with_recommended_actions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            _make_page_inflight_expired(job_dir, 2)
+
+            runner.resume("job", allow_partial=True)
+            payload = runner.reconcile("job")
+
+            attempts = payload["ambiguous_attempts"]
+            self.assertEqual(len(attempts), 1)
+            self.assertEqual(attempts[0]["page_number"], 2)
+            self.assertIn("supersede", attempts[0]["recommended_actions"])
+            self.assertIn("accept", attempts[0]["recommended_actions"])
+
+
+class ReconcileCliTests(unittest.TestCase):
+    def test_cli_reconcile_supersede_requeues_page(self) -> None:
+        from paperscale.cli import main as paperscale_main
+
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            _run_job(state_root, "job", pages=2)
+            job_dir = state_root / "jobs" / "job"
+            _make_page_ambiguous(job_dir, 2)
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = paperscale_main(["reconcile", "job", "--state-root", str(state_root), "--supersede", "2"])
+            self.assertEqual(code, 0)
+            self.assertEqual(_read_status(job_dir)["pages"]["2"]["state"], "pending")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recovery_retry_redesign.py
+++ b/tests/test_recovery_retry_redesign.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from paperscale.providers.base import PageOcrResponse, ProviderError
+from paperscale.runner import DocumentOcrRunner, RunnerConfig
+
+
+@dataclass(frozen=True)
+class _Rendered:
+    page_number: int
+    image_bytes: bytes
+    image_hash: str
+    media_type: str = "image/png"
+
+
+class _Renderer:
+    def __init__(self, n: int) -> None:
+        self._pages = [f"page-{i}".encode() for i in range(1, n + 1)]
+
+    @property
+    def page_count(self) -> int:
+        return len(self._pages)
+
+    def render_page(self, page_number: int) -> _Rendered:
+        image = self._pages[page_number - 1]
+        return _Rendered(page_number, image, hashlib.sha256(image).hexdigest())
+
+
+class _ScriptedProvider:
+    """Returns markdown per call; records the request decoding/fingerprint each time."""
+
+    name = "scripted"
+
+    def __init__(self, outputs: list[str]) -> None:
+        self._outputs = list(outputs)
+        self.calls: list[dict[str, Any]] = []
+
+    def send(self, request: Any) -> PageOcrResponse:
+        self.calls.append({"decoding": dict(request.decoding), "fingerprint": request.fingerprint})
+        if not self._outputs:
+            raise ProviderError("exhausted")
+        return PageOcrResponse(markdown=self._outputs.pop(0), provider_request_id=request.fingerprint)
+
+
+def _runner(state_root: Path, provider: Any, *, pages: int = 1, **cfg: Any) -> DocumentOcrRunner:
+    base = dict(state_root=state_root, base_url="http://fake/v1", model="m", profile="deepseek_ocr_2", max_in_flight_requests=1)
+    base.update(cfg)
+    return DocumentOcrRunner(
+        RunnerConfig(**base),
+        provider=provider,
+        renderer_factory=lambda _p, _o: _Renderer(pages),
+        sleeper=lambda _s: None,
+    )
+
+
+class RetryCapTests(unittest.TestCase):
+    def test_repeated_content_failure_is_capped_then_terminal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".paperscale"
+            provider = _ScriptedProvider(["same same same same same same"] * 10)
+            runner = _runner(root, provider, max_attempts=3)
+            status = runner.run(input_path=root / "i.pdf", output_path=root / "o.md", job_id="j", allow_partial=True)
+            self.assertEqual(status.failed_terminal, 1)
+            self.assertEqual(status.succeeded, 0)
+            self.assertEqual(len(provider.calls), 3)  # capped at max_attempts
+            self.assertFalse((root / "jobs" / "j" / "artifacts" / "pages" / "1.json").exists())
+
+    def test_remediation_escalates_decoding_across_attempts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".paperscale"
+            provider = _ScriptedProvider(["same same same same same same"] * 10)
+            runner = _runner(root, provider, max_attempts=4)
+            runner.run(input_path=root / "i.pdf", output_path=root / "o.md", job_id="j", allow_partial=True)
+            # repeated_ngram -> repetition_penalty raised on each subsequent attempt.
+            first = provider.calls[0]["decoding"].get("repetition_penalty", 1.0)
+            later = provider.calls[-1]["decoding"].get("repetition_penalty", 1.0)
+            self.assertGreater(later, first)
+            # Each remediated attempt changes the request fingerprint (intended).
+            fingerprints = [c["fingerprint"] for c in provider.calls]
+            self.assertEqual(len(set(fingerprints)), len(fingerprints))
+
+    def test_content_failure_recovers_after_remediation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".paperscale"
+            provider = _ScriptedProvider(["same same same same same same", "same same same same same same", "# Good\n\nReal text body."])
+            runner = _runner(root, provider, max_attempts=8)
+            status = runner.run(input_path=root / "i.pdf", output_path=root / "o.md", job_id="j")
+            self.assertEqual(status.succeeded, 1)
+            self.assertEqual(len(provider.calls), 3)
+
+
+def _png(shade: int) -> bytes:
+    from PIL import Image
+    import io as _io
+
+    buf = _io.BytesIO()
+    Image.new("L", (64, 64), color=shade).save(buf, "PNG")
+    return buf.getvalue()
+
+
+class _PngRenderer:
+    def __init__(self, n: int, shade: int) -> None:
+        self._n = n
+        self._png = _png(shade)
+
+    @property
+    def page_count(self) -> int:
+        return self._n
+
+    def render_page(self, page_number: int) -> _Rendered:
+        return _Rendered(page_number, self._png, hashlib.sha256(self._png).hexdigest())
+
+
+class BlankPageTests(unittest.TestCase):
+    def test_blank_page_with_empty_ocr_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".paperscale"
+            provider = _ScriptedProvider([""])  # model returns empty for a blank page
+            runner = DocumentOcrRunner(
+                RunnerConfig(state_root=root, base_url="http://fake/v1", model="m", profile="deepseek_ocr_2", max_in_flight_requests=1),
+                provider=provider,
+                renderer_factory=lambda _p, _o: _PngRenderer(1, shade=255),  # all-white = blank
+                sleeper=lambda _s: None,
+            )
+            status = runner.run(input_path=root / "i.pdf", output_path=root / "o.md", job_id="j")
+            self.assertEqual(status.succeeded, 1)
+            self.assertTrue(status.complete)
+            self.assertEqual(len(provider.calls), 1)  # accepted on first sight, no re-rolls
+
+    def test_inky_page_with_empty_ocr_is_not_treated_as_blank(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".paperscale"
+            provider = _ScriptedProvider([""] * 10)  # empty on a content-bearing page
+            runner = DocumentOcrRunner(
+                RunnerConfig(state_root=root, base_url="http://fake/v1", model="m", profile="deepseek_ocr_2", max_in_flight_requests=1, max_attempts=3),
+                provider=provider,
+                renderer_factory=lambda _p, _o: _PngRenderer(1, shade=0),  # all-black = lots of ink
+                sleeper=lambda _s: None,
+            )
+            status = runner.run(input_path=root / "i.pdf", output_path=root / "o.md", job_id="j", allow_partial=True)
+            self.assertEqual(status.succeeded, 0)
+            self.assertEqual(status.failed_terminal, 1)
+
+
+class AdoptThenRequeueTests(unittest.TestCase):
+    def test_resume_adopts_matching_artifact_without_provider_call(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".paperscale"
+            provider = _ScriptedProvider(["# Page\n\nBody text here."])
+            runner = _runner(root, provider, pages=1)
+            runner.run(input_path=root / "i.pdf", output_path=root / "o.md", job_id="j")
+            job_dir = root / "jobs" / "j"
+
+            # Force the page back into a crashed in_flight state (lease expired) while
+            # the durable artifact survives with a matching fingerprint.
+            status_idx = json.loads((job_dir / "indexes" / "status.json").read_text())
+            artifact = json.loads((job_dir / "artifacts" / "pages" / "1.json").read_text())
+            attempt_id = status_idx["pages"]["1"]["attempt_id"]
+            ledger_path = job_dir / "ledger" / f"{attempt_id}.json"
+            attempt = json.loads(ledger_path.read_text())
+            attempt.update({"state": "in_flight", "result_pointer": None, "lease_expires_at": 1.0, "fingerprint": artifact["fingerprint"]})
+            ledger_path.write_text(json.dumps(attempt, sort_keys=True))
+            status_idx["pages"]["1"] = {"state": "in_flight", "epoch": 1, "attempt_id": attempt_id, "fingerprint": artifact["fingerprint"]}
+            (job_dir / "indexes" / "status.json").write_text(json.dumps(status_idx, sort_keys=True))
+
+            runner.provider = _ScriptedProvider([])  # any send would raise -> proves no call
+            status = runner.resume("j")
+            self.assertTrue(status.complete)
+
+
+class SettledReportingTests(unittest.TestCase):
+    def test_terminal_failure_makes_job_settled_not_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".paperscale"
+            # page 1 refuses (terminal on first sight), page 2 succeeds.
+            provider = _ScriptedProvider(["I'm sorry, I can't assist with that.", "# Page 2\n\nReal body."])
+            runner = _runner(root, provider, pages=2)
+            status = runner.run(input_path=root / "i.pdf", output_path=root / "o.md", job_id="j", allow_partial=True)
+            self.assertEqual(status.failed_terminal, 1)
+            self.assertEqual(status.succeeded, 1)
+            self.assertFalse(status.complete)
+            self.assertTrue(status.settled)
+            self.assertTrue(status.has_terminal_failures)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runner_scheduling.py
+++ b/tests/test_runner_scheduling.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from paperscale.providers.base import PageOcrResponse, ProviderError
+from paperscale.resources import ResourceGovernor, ResourceKind
+from paperscale.runner import DocumentOcrRunner, RunnerConfig
+
+
+@dataclass(frozen=True)
+class _FakeRenderedPage:
+    page_number: int
+    image_bytes: bytes
+    image_hash: str
+    media_type: str = "image/png"
+
+
+class _FakeRenderer:
+    def __init__(self, pages: list[bytes]) -> None:
+        self._pages = pages
+
+    @property
+    def page_count(self) -> int:
+        return len(self._pages)
+
+    def render_page(self, page_number: int) -> _FakeRenderedPage:
+        image = self._pages[page_number - 1]
+        return _FakeRenderedPage(page_number, image, hashlib.sha256(image).hexdigest())
+
+
+class _ScriptedProvider:
+    """Raises ProviderError for the first `fail_first` calls, then succeeds."""
+
+    name = "scripted"
+
+    def __init__(self, *, fail_first: int = 0, always_fail: bool = False) -> None:
+        self.fail_first = fail_first
+        self.always_fail = always_fail
+        self.calls = 0
+
+    def send(self, request: Any) -> PageOcrResponse:
+        self.calls += 1
+        if self.always_fail or self.calls <= self.fail_first:
+            raise ProviderError(f"boom {self.calls}")
+        return PageOcrResponse(markdown=f"# Page\n\nBody {request.page_id}", provider_request_id=request.fingerprint)
+
+
+class RecordingGovernor(ResourceGovernor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.acquired: list[ResourceKind | str] = []
+
+    def acquire(self, kind: ResourceKind | str):  # type: ignore[override]
+        self.acquired.append(kind)
+        return super().acquire(kind)
+
+
+def _runner(state_root: Path, provider: Any, *, governor: Any = None, sleeper: Any = None, capacity: str = "local-vllm-small") -> DocumentOcrRunner:
+    return DocumentOcrRunner(
+        RunnerConfig(state_root=state_root, base_url="http://fake/v1", model="mock-vlm", capacity=capacity),
+        provider=provider,
+        renderer_factory=lambda _path, _options: _FakeRenderer([b"page-1"]),
+        governor=governor,
+        sleeper=sleeper,
+    )
+
+
+class GovernedOrderingTests(unittest.TestCase):
+    def test_page_processing_acquires_resources_in_global_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            governor = RecordingGovernor()
+            runner = _runner(state_root, _ScriptedProvider(), governor=governor)
+            status = runner.run(input_path=state_root / "in.pdf", output_path=state_root / "out.md", job_id="job")
+            self.assertEqual(status.succeeded, 1)
+            self.assertIn(ResourceKind.SCHEDULER, governor.acquired)
+            self.assertIn(ResourceKind.RENDER, governor.acquired)
+            self.assertIn(ResourceKind.PROVIDER, governor.acquired)
+            self.assertIn(ResourceKind.PAGE_LEASE, governor.acquired)
+            self.assertIn(ResourceKind.STATE_STORE, governor.acquired)
+            self.assertLess(
+                governor.acquired.index(ResourceKind.RENDER),
+                governor.acquired.index(ResourceKind.PROVIDER),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runner_scheduling.py
+++ b/tests/test_runner_scheduling.py
@@ -89,5 +89,43 @@ class GovernedOrderingTests(unittest.TestCase):
             )
 
 
+class RetryBackoffTests(unittest.TestCase):
+    def test_transient_provider_errors_are_retried_with_backoff_then_succeed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            sleeps: list[float] = []
+            provider = _ScriptedProvider(fail_first=2)
+            runner = _runner(state_root, provider, sleeper=sleeps.append, capacity="local-vllm-small")
+            status = runner.run(input_path=state_root / "in.pdf", output_path=state_root / "out.md", job_id="job")
+            self.assertEqual(status.succeeded, 1)
+            self.assertEqual(provider.calls, 3)          # 2 failures + 1 success
+            self.assertEqual(sleeps, [1.0, 2.0])         # exponential backoff from local-vllm-small
+
+
+class CircuitBreakerTests(unittest.TestCase):
+    def test_circuit_opens_after_threshold_and_leaves_remaining_pages_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            sleeps: list[float] = []
+            provider = _ScriptedProvider(always_fail=True)
+            runner = DocumentOcrRunner(
+                RunnerConfig(state_root=state_root, base_url="http://fake/v1", model="mock-vlm", capacity="local-vllm-small"),
+                provider=provider,
+                renderer_factory=lambda _path, _options: _FakeRenderer([b"page-1", b"page-2"]),
+                sleeper=sleeps.append,
+            )
+            status = runner.run(
+                input_path=state_root / "in.pdf",
+                output_path=state_root / "out.md",
+                job_id="job",
+                allow_partial=True,
+            )
+            self.assertEqual(provider.calls, 3)            # threshold=3 attempts on page 1 trips the breaker
+            self.assertEqual(status.succeeded, 0)
+            self.assertEqual(status.failed_retryable, 1)   # page 1 left failed_retryable
+            self.assertEqual(status.pending, 1)            # page 2 never started
+            self.assertEqual(len(sleeps), 2)               # 2 backoffs before the 3rd failure
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runner_scheduling.py
+++ b/tests/test_runner_scheduling.py
@@ -109,7 +109,12 @@ class CircuitBreakerTests(unittest.TestCase):
             sleeps: list[float] = []
             provider = _ScriptedProvider(always_fail=True)
             runner = DocumentOcrRunner(
-                RunnerConfig(state_root=state_root, base_url="http://fake/v1", model="mock-vlm", capacity="local-vllm-small"),
+                # Pin in-flight to 1 so the breaker test is deterministic/sequential:
+                # page 1 trips the circuit before page 2 is ever pulled.
+                RunnerConfig(
+                    state_root=state_root, base_url="http://fake/v1", model="mock-vlm",
+                    capacity="local-vllm-small", max_in_flight_requests=1,
+                ),
                 provider=provider,
                 renderer_factory=lambda _path, _options: _FakeRenderer([b"page-1", b"page-2"]),
                 sleeper=sleeps.append,

--- a/tests/test_schema_fail_closed.py
+++ b/tests/test_schema_fail_closed.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from paperscale.contracts import UnknownSchemaVersionError
+from paperscale.providers.base import PageOcrResponse
+from paperscale.runner import DocumentOcrRunner, RunnerConfig
+
+
+@dataclass(frozen=True)
+class _FakeRenderedPage:
+    page_number: int
+    image_bytes: bytes
+    image_hash: str
+    media_type: str = "image/png"
+
+
+class _FakeRenderer:
+    def __init__(self, pages: list[bytes]) -> None:
+        self._pages = pages
+
+    @property
+    def page_count(self) -> int:
+        return len(self._pages)
+
+    def render_page(self, page_number: int) -> _FakeRenderedPage:
+        image = self._pages[page_number - 1]
+        return _FakeRenderedPage(page_number, image, hashlib.sha256(image).hexdigest())
+
+
+class _OkProvider:
+    name = "ok-provider"
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+
+    def send(self, request: Any) -> PageOcrResponse:
+        return PageOcrResponse(markdown=self._responses.pop(0), provider_request_id=request.fingerprint)
+
+
+def _bump_schema(path: Path, *, version: int = 2) -> None:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["schema_version"] = version
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _run_completed_job(state_root: Path, job_id: str, *, pages: int = 1) -> DocumentOcrRunner:
+    runner = DocumentOcrRunner(
+        RunnerConfig(state_root=state_root, base_url="http://fake/v1", model="mock-vlm"),
+        provider=_OkProvider([f"# Page {n}\n\nBody {n}" for n in range(1, pages + 1)]),
+        renderer_factory=lambda _path, _options: _FakeRenderer([f"page-{n}".encode() for n in range(1, pages + 1)]),
+    )
+    runner.run(input_path=state_root / "in.pdf", output_path=state_root / "out.md", job_id=job_id)
+    return runner
+
+
+class SchemaFailClosedTests(unittest.TestCase):
+    def test_status_fails_closed_on_future_status_index_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_completed_job(state_root, "job-status")
+            _bump_schema(state_root / "jobs" / "job-status" / "indexes" / "status.json")
+            with self.assertRaises(UnknownSchemaVersionError):
+                runner.status("job-status")
+
+    def test_resume_fails_closed_on_future_manifest_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_completed_job(state_root, "job-manifest")
+            _bump_schema(state_root / "jobs" / "job-manifest" / "manifest.json")
+            with self.assertRaises(UnknownSchemaVersionError):
+                runner.resume("job-manifest")
+
+    def test_reconcile_fails_closed_on_future_reconcile_index_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_completed_job(state_root, "job-reconcile")
+            _bump_schema(state_root / "jobs" / "job-reconcile" / "indexes" / "reconcile.json")
+            with self.assertRaises(UnknownSchemaVersionError):
+                runner.reconcile("job-reconcile")
+
+    def test_fsck_fails_closed_on_future_manifest_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_completed_job(state_root, "job-fsck")
+            _bump_schema(state_root / "jobs" / "job-fsck" / "manifest.json")
+            with self.assertRaises(UnknownSchemaVersionError):
+                runner.fsck("job-fsck")
+
+    def test_repair_index_fails_closed_on_future_artifact_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_completed_job(state_root, "job-repair")
+            _bump_schema(state_root / "jobs" / "job-repair" / "artifacts" / "pages" / "1.json")
+            with self.assertRaises(UnknownSchemaVersionError):
+                runner.repair_index("job-repair")
+
+    def test_resume_assembly_fails_closed_on_future_artifact_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_completed_job(state_root, "job-assemble")
+            _bump_schema(state_root / "jobs" / "job-assemble" / "artifacts" / "pages" / "1.json")
+            with self.assertRaises(UnknownSchemaVersionError):
+                runner.resume("job-assemble")
+
+    def test_resume_recovery_fails_closed_on_future_ledger_attempt_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_completed_job(state_root, "job-ledger")
+            job_dir = state_root / "jobs" / "job-ledger"
+            attempt_path = next((job_dir / "ledger").glob("*.json"))
+            attempt_id = attempt_path.stem
+            _bump_schema(attempt_path)
+            # Force the page back into an in-flight state so resume must read the ledger attempt.
+            status_path = job_dir / "indexes" / "status.json"
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+            status["pages"]["1"] = {"state": "in_flight", "epoch": 1, "attempt_id": attempt_id}
+            status_path.write_text(json.dumps(status, sort_keys=True), encoding="utf-8")
+            with self.assertRaises(UnknownSchemaVersionError):
+                runner.resume("job-ledger")
+
+    def test_status_succeeds_on_current_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / ".paperscale"
+            runner = _run_completed_job(state_root, "job-ok")
+            self.assertTrue(runner.status("job-ok").complete)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements `docs/concurrency-and-queuing.md` and `docs/recovery-retry-redesign.md`, and makes every scanned law PDF OCR without fail against a real DeepSeek-OCR-2 vLLM server (**validated 233/233 pages over 30 docs, 0 failures**).

## Concurrency
- Async full-lifecycle worker pool replaces the sequential loop (`_run_pool`/`_worker`).
- Three backpressure knobs: `max_in_flight_requests`, `max_open_documents`, `render_ahead`.
- Single serialized index writer with coalesced flush; **fsync the truth** (artifacts/ledger), atomic-but-unsynced derived indexes.
- Async OpenAI-compatible chat provider with the httpx pool sized to in-flight.
- AIMD adaptive concurrency (`AdaptiveLimiter`) wired to `ProviderOverloadController` with signal hygiene (content/parse/empty never throttle).
- Multi-process claim tier: `O_EXCL` `ClaimStore` (lease/heartbeat/epoch), durable `done` markers, `enqueue` + `work` CLI commands.

## Recovery / retry
- Adopt-then-requeue recovery; auto-requeue by default, `ambiguous` only when `--metered`.
- Hard `max_attempts` cap with terminal demotion; profile-owned diagnostic→remediation ladder with accumulated overrides; settled-vs-progressing reporting + exit codes.

## Rendering / model robustness (make all documents complete)
- Switch rasterizer to **PDFium (`pypdfium2`)** — `pdf_oxide` silently skipped scanned ImageMask/CCITT pages → blank image; drop the `pdf-oxide` dep.
- Fix `deepseek_ocr_2` prompt to the native `<image>\nConvert the document to markdown.` (the verbose prompt caused empty completions); repetition remediation step → 0.15.
- Accept genuinely-blank pages (ink-gated) whose OCR is empty/looping as successful empty pages, so a blank separator never strands a job.

## Verification
- 154 tests pass (`poetry run pytest`), `ruff` clean.
- Real-server runs: individual scanned docs 6/6 and 22/22 (incl. a blank page → empty section); broad load test **233/233, 0 terminal failures**, p50 4.6 s / p95 9.6 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)