### PR TITLE
feat(pipeline): soft-drop requests on client fd exhaustion

### DIFF
--- a/src/paperscale/pipeline.py
+++ b/src/paperscale/pipeline.py
@@ -29,6 +29,7 @@ import asyncio
 import atexit
 import base64
 import datetime
+import errno
 import glob
 import hashlib
 import json
@@ -255,22 +256,47 @@ async def try_single_page_with_backoff(
     image_base64: str,
     render_is_blank: bool,
 ) -> PageResult | None:
-    """Wrapper around try_single_page that handles connection errors with exponential backoff."""
-    MAX_BACKOFF_ATTEMPTS = 10
+    """Wrapper around try_single_page that retries transient send-side errors.
 
-    for backoff_count in range(MAX_BACKOFF_ATTEMPTS):
+    File-descriptor exhaustion on the sending machine (EMFILE/ENFILE) is a soft
+    drop: the request is backed off and retried indefinitely (capped delay)
+    rather than counted as a failure, so it never consumes one of the page's
+    retries and never aborts the job. It self-resolves as in-flight requests
+    release their sockets. Other connection errors use a bounded exponential
+    backoff and abort the job only if they never recover.
+    """
+    MAX_BACKOFF_ATTEMPTS = 10
+    FD_MAX_BACKOFF_SECONDS = 30
+
+    conn_backoff = 0
+    fd_backoff = 0
+    while True:
         try:
             return await try_single_page(args, pdf_orig_path, page_num, attempt, image_base64, render_is_blank)
-        except (ConnectionError, OSError, asyncio.TimeoutError) as e:
-            sleep_delay = 10 * (2**backoff_count)
+        except OSError as e:
+            if e.errno in (errno.EMFILE, errno.ENFILE):
+                # Out of file descriptors on this machine: drop the request for now
+                # without failing it (does not consume a page retry).
+                sleep_delay = min(2**fd_backoff, FD_MAX_BACKOFF_SECONDS)
+                fd_backoff += 1
+                metrics.add_metrics(fd_exhaustion_drops=1)
+                logger.warning(
+                    f"Out of file descriptors sending {pdf_orig_path}-{page_num} (errno {e.errno}); "
+                    f"dropping request without failing it, retrying in {sleep_delay}s"
+                )
+                await asyncio.sleep(sleep_delay)
+                continue
+
+            conn_backoff += 1
+            if conn_backoff > MAX_BACKOFF_ATTEMPTS:
+                logger.error(f"Max backoff attempts reached for {pdf_orig_path}-{page_num}, terminating job")
+                sys.exit(1)
+            sleep_delay = 10 * (2 ** (conn_backoff - 1))
             logger.warning(
                 f"Connection error on {pdf_orig_path}-{page_num} attempt {attempt}: {type(e).__name__}: {e}. "
-                f"Backoff {backoff_count + 1}/{MAX_BACKOFF_ATTEMPTS}, sleeping {sleep_delay}s"
+                f"Backoff {conn_backoff}/{MAX_BACKOFF_ATTEMPTS}, sleeping {sleep_delay}s"
             )
             await asyncio.sleep(sleep_delay)
-
-    logger.error(f"Max backoff attempts reached for {pdf_orig_path}-{page_num}, terminating job")
-    sys.exit(1)
 
 
 async def process_page(args, worker_id: int, pdf_orig_path: str, pdf_local_path: str, page_num: int) -> PageResult:

--- a/tests/test_pipeline_units.py
+++ b/tests/test_pipeline_units.py
@@ -1,9 +1,12 @@
 """Tests for pure pipeline helpers (no server, no rendering)."""
 
+import errno
 import os
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 from paperscale import pipeline
 from paperscale.pipeline import PageResult
@@ -111,6 +114,47 @@ class WipeWorkspaceTests(unittest.TestCase):
             pipeline._wipe_workspace_progress(ws)
             for sub in ("results", "done_flags", "worker_locks"):
                 self.assertFalse((Path(ws) / sub).exists())
+
+
+class FdExhaustionBackoffTests(unittest.IsolatedAsyncioTestCase):
+    """Out-of-fd (EMFILE/ENFILE) is a soft drop: retried, never a counted failure."""
+
+    async def test_fd_exhaustion_is_dropped_then_succeeds(self):
+        good = _page(1, "ok")
+        calls = {"n": 0}
+
+        async def fake_try(args, pdf, page, attempt, image, blank):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise OSError(errno.EMFILE, "Too many open files")
+            return good
+
+        with (
+            mock.patch.object(pipeline, "try_single_page", fake_try),
+            mock.patch.object(pipeline.asyncio, "sleep", new=mock.AsyncMock()) as sleep,
+        ):
+            result = await pipeline.try_single_page_with_backoff(
+                SimpleNamespace(), "doc.pdf", 1, attempt=0, image_base64="x", render_is_blank=False
+            )
+
+        # The page recovers without ever returning a failure (None) to the caller,
+        # so process_page's per-page retry budget is untouched.
+        self.assertIs(result, good)
+        self.assertEqual(calls["n"], 3)  # two soft drops + one success
+        self.assertEqual(sleep.await_count, 2)
+
+    async def test_non_fd_connection_error_aborts_after_max_backoff(self):
+        async def always_refused(*args, **kwargs):
+            raise ConnectionError("connection refused")
+
+        with (
+            mock.patch.object(pipeline, "try_single_page", always_refused),
+            mock.patch.object(pipeline.asyncio, "sleep", new=mock.AsyncMock()),
+        ):
+            with self.assertRaises(SystemExit):
+                await pipeline.try_single_page_with_backoff(
+                    SimpleNamespace(), "doc.pdf", 1, attempt=0, image_base64="x", render_is_blank=False
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When the **sending** machine runs out of file descriptors (`EMFILE`/`ENFILE`, "too many open files"), the request is now a transient **soft drop** instead of a failure:

- Does **not** return a failure to `process_page`, so it never consumes one of `--max_page_retries`.
- Retried indefinitely with a capped backoff (`min(2**n, 30s)`); never trips the `MAX_BACKOFF_ATTEMPTS → sys.exit(1)` abort that ordinary connection errors do.
- Self-resolves as in-flight requests release their sockets (the concurrency-limit slot is freed while waiting).
- Logged and counted in metrics as `fd_exhaustion_drops`.

Real connection errors (refused/reset/timeout) keep their existing bounded backoff + job-abort behavior.

Tests: 51 passed (2 new); ruff + pyrefly clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)