### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paperscale"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local, model-agnostic OCR-to-Markdown at scale (an olmOCR-style pipeline)"
 authors = [
     {name = "charitarthchugh",email = "37895518+charitarthchugh@users.noreply.github.com"}

--- a/src/paperscale/version.py
+++ b/src/paperscale/version.py
@@ -1,5 +1,5 @@
 _MAJOR = "0"
-_MINOR = "3"
+_MINOR = "4"
 _PATCH = "0"
 
 VERSION_SHORT = f"{_MAJOR}.{_MINOR}"


### PR DESCRIPTION
Version bump to **0.4.0** for the LightOnOCR-2 model support (`--ocr-model lightonocr2` / `lightonocr2-soup`) and the legal-doc quality-gate fixes merged in #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)