### PR TITLE
feat(models): add GLM-OCR, Qianfan-OCR, Infinity-Parser2 Flash, Surya OCR 2 adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ It keeps olmOCR's document management, queueing, and CLI 1:1, with two additions
   SOTA 1B Markdown-OCR model — image-only prompt, rendered at 1540px by default;
   `lightonocr2-soup` is the same adapter on the more-robust
   [`-ocr-soup`](https://huggingface.co/lightonai/LightOnOCR-2-1B-ocr-soup)
-  merged checkpoint).
+  merged checkpoint; `glm-ocr`, `qianfan-ocr`, `infinity-parser2-flash`, and
+  `surya2` add four more document-OCR VLMs, documented below).
 - **Opt-out resume** — completed work items are skipped on restart by default
   (olmOCR's done-flag behavior). `--no-resume` wipes prior progress and
   reprocesses the workspace from scratch.
@@ -65,8 +66,8 @@ poetry run paperscale ./workspace \
   flags, `results/*.jsonl`, and (with `--markdown`) `markdown/` live.
 - `--pdfs` — local PDF/image paths, a glob (`'docs/*.pdf'`), `.tar.gz` tarballs,
   or a `.txt` file listing one path per line.
-- `--ocr-model {lightonocr2,lightonocr2-soup,markdown,olmocr}` — which OCR
-  adapter drives prompting/parsing.
+- `--ocr-model {glm-ocr,infinity-parser2-flash,lightonocr2,lightonocr2-soup,markdown,olmocr,qianfan-ocr,surya2}`
+  — which OCR adapter drives prompting/parsing.
 - `--model` — the served model id sent in each request (or a Hugging Face path
   for the internal server).
 
@@ -120,6 +121,77 @@ automatically; forward vLLM's recommended flags as trailing args:
 ```bash
 poetry run paperscale ./workspace --pdfs './docs/*.pdf' --ocr-model lightonocr2 --markdown \
   --mm-processor-cache-gb 0 --no-enable-prefix-caching --limit-mm-per-prompt '{"image": 1}'
+```
+
+### GLM-OCR
+
+`--ocr-model glm-ocr` drives [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR)
+(`zai-org/GLM-OCR`, ~0.9B, Apache-2.0), a GLM-4.1V-derived VLM fine-tuned for
+document transcription. The page image is sent with a full-page instruction and
+the model returns the whole page as Markdown (tables as Markdown, formulas as
+LaTeX) in a single call. vLLM serves it natively via the `glm_ocr` architecture
+(vLLM PR #33005); use a recent vLLM build and upgrade `transformers` alongside it.
+
+```bash
+vllm serve zai-org/GLM-OCR --port 8000 --limit-mm-per-prompt '{"image": 1}'
+
+poetry run paperscale ./workspace --pdfs './docs/*.pdf' \
+  --ocr-model glm-ocr --server http://127.0.0.1:8000/v1 --markdown
+```
+
+### Qianfan-OCR
+
+`--ocr-model qianfan-ocr` drives
+[Qianfan-OCR](https://huggingface.co/baidu/Qianfan-OCR) (`baidu/Qianfan-OCR`,
+~4B), a Qianfan-ViT + Qwen3-4B document model. One image + prompt call returns
+clean reading-ordered Markdown (HTML tables, `$$…$$` LaTeX). vLLM runs it as an
+`InternVLChatModel` via `--hf-overrides`:
+
+```bash
+vllm serve baidu/Qianfan-OCR --port 8000 --trust-remote-code \
+  --hf-overrides '{"architectures": ["InternVLChatModel"]}' --limit-mm-per-prompt '{"image": 1}'
+
+poetry run paperscale ./workspace --pdfs './docs/*.pdf' \
+  --ocr-model qianfan-ocr --server http://127.0.0.1:8000/v1 --markdown
+```
+
+The adapter raises `max_tokens` to 12000 for long pages and defensively strips a
+leading `<think>…</think>` layout block (only emitted when `enable_thinking=True`,
+which paperscale never sets).
+
+### Infinity-Parser2 Flash
+
+`--ocr-model infinity-parser2-flash` drives
+[`infly/Infinity-Parser2-Flash`](https://huggingface.co/infly/Infinity-Parser2-Flash),
+a ~2B Qwen3.5-VL document parser, in **doc2md** mode (Markdown with HTML tables
+and LaTeX) rather than its native bbox-JSON mode. Qwen3 reasoning is disabled via
+the top-level `chat_template_kwargs={"enable_thinking": false}` request key. Serve
+it on vLLM ≥ 0.20 (Python 3.13):
+
+```bash
+vllm serve infly/Infinity-Parser2-Flash --port 8000 --trust-remote-code \
+  --reasoning-parser qwen3 --mm-encoder-tp-mode data --mm-processor-cache-type shm \
+  --enable-prefix-caching --limit-mm-per-prompt '{"image": 1}'
+
+poetry run paperscale ./workspace --pdfs './docs/*.pdf' \
+  --ocr-model infinity-parser2-flash --server http://127.0.0.1:8000/v1 --markdown
+```
+
+### Surya OCR 2
+
+`--ocr-model surya2` drives
+[Surya OCR 2](https://huggingface.co/datalab-to/surya-ocr-2)
+(`datalab-to/surya-ocr-2`, ~0.65B, `Qwen3_5ForConditionalGeneration`). Its
+full-page-OCR mode emits reading-ordered **layout-HTML** (`<div data-label=…>`
+blocks, `<math>` KaTeX, HTML `<table>`); paperscale converts that to Markdown
+(headings, lists, Markdown tables, and `\( … \)` / `\[ … \]` LaTeX). Serve it on a
+recent vLLM with native `qwen3_5` support (v0.20.0+; avoid v0.18.0):
+
+```bash
+vllm serve datalab-to/surya-ocr-2 --port 8000 --limit-mm-per-prompt '{"image": 1}'
+
+poetry run paperscale ./workspace --pdfs './docs/*.pdf' \
+  --ocr-model surya2 --server http://127.0.0.1:8000/v1 --markdown
 ```
 
 ## Outputs

--- a/poetry.lock
+++ b/poetry.lock
@@ -20,6 +20,29 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 trio = ["trio (>=0.32.0)"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.7.0"
+groups = ["main"]
+files = [
+    {file = "beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9"},
+    {file = "beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7"},
+]
+
+[package.dependencies]
+soupsieve = ">=1.6.1"
+typing-extensions = ">=4.0.0"
+
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -566,6 +589,22 @@ html5 = ["html5lib"]
 htmlsoup = ["BeautifulSoup4"]
 
 [[package]]
+name = "markdownify"
+version = "1.2.2"
+description = "Convert HTML to markdown."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a"},
+    {file = "markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09"},
+]
+
+[package.dependencies]
+beautifulsoup4 = ">=4.9,<5"
+six = ">=1.15,<2"
+
+[[package]]
 name = "packaging"
 version = "26.2"
 description = "Core utilities for Python packages"
@@ -1001,6 +1040,30 @@ files = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"},
+    {file = "soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.68.1"
 description = "Fast, Extensible Progress Meter"
@@ -1029,7 +1092,6 @@ description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.12\""
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -1163,4 +1225,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "b25b65205d27556bb9a0d20bbd2741aa4616df65d025cd6a02b278d4a7485b6b"
+content-hash = "132c0e0707151700f17e78c3942ba8218adb6b96c13d89ad764c56854f801e2e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "zstandard (>=0.22.0,<0.24.0)",
     "pyyaml (>=6.0.0,<7.0.0)",
     "lingua-language-detector (>=2.0.0,<3.0.0)",
-    "img2pdf (>=0.5.0,<0.7.0)"
+    "img2pdf (>=0.5.0,<0.7.0)",
+    "markdownify (>=1.2.0,<2.0.0)"
 ]
 
 [tool.poetry]

--- a/src/paperscale/models/__init__.py
+++ b/src/paperscale/models/__init__.py
@@ -7,9 +7,13 @@ default and works with any OpenAI-compatible model that emits Markdown.
 from __future__ import annotations
 
 from paperscale.models.base import OCRModel
+from paperscale.models.glmocr import GLMOCRModel
+from paperscale.models.infinity_parser import InfinityParser2FlashModel
 from paperscale.models.lightonocr import LightOnOCRModel, LightOnOCRSoupModel
 from paperscale.models.markdown import MarkdownModel
 from paperscale.models.olmocr import OlmOCRModel
+from paperscale.models.qianfan import QianfanOCRModel
+from paperscale.models.surya import Surya2Model
 
 DEFAULT_MODEL = "markdown"
 
@@ -18,6 +22,10 @@ MODEL_REGISTRY: dict[str, type[OCRModel]] = {
     "olmocr": OlmOCRModel,
     "lightonocr2": LightOnOCRModel,
     "lightonocr2-soup": LightOnOCRSoupModel,
+    "glm-ocr": GLMOCRModel,
+    "qianfan-ocr": QianfanOCRModel,
+    "infinity-parser2-flash": InfinityParser2FlashModel,
+    "surya2": Surya2Model,
 }
 
 
@@ -37,6 +45,10 @@ __all__ = [
     "OlmOCRModel",
     "LightOnOCRModel",
     "LightOnOCRSoupModel",
+    "GLMOCRModel",
+    "QianfanOCRModel",
+    "InfinityParser2FlashModel",
+    "Surya2Model",
     "MODEL_REGISTRY",
     "DEFAULT_MODEL",
     "build_ocr_model",

--- a/src/paperscale/models/glmocr.py
+++ b/src/paperscale/models/glmocr.py
@@ -1,0 +1,37 @@
+"""GLM-OCR adapter: GLM-4.1V-derived VLM, single-call full-page Markdown.
+
+GLM-OCR (https://huggingface.co/zai-org/GLM-OCR) is a ~0.9B vision-language
+model derived from GLM-4.1V and fine-tuned for document transcription. It takes
+a page image plus a full-page instruction and emits the whole page as Markdown
+in one call, so parsing reuses the generic Markdown path. Selected with
+``--ocr-model glm-ocr``.
+
+vLLM serves it natively via the ``glm_ocr`` architecture (added in vLLM
+PR #33005); run a recent build carrying that arch and upgrade ``transformers``
+alongside. The vendor's best-quality path is a two-stage layout pipeline
+(detect regions, then transcribe each); this adapter uses the simpler
+single-call full-page path, which keeps it one image -> one text -> one
+``PageResponse`` like the other Markdown adapters.
+"""
+
+from __future__ import annotations
+
+from paperscale.models.markdown import MarkdownModel
+
+# Full-page transcription instruction sent with every page image.
+GLM_OCR_PROMPT = (
+    "Recognize the text in the image and output it in Markdown format. Preserve the "
+    "original layout (headings, paragraphs, lists, tables, formulas). Render tables as "
+    "Markdown tables and formulas as LaTeX. Do not fabricate content that does not exist "
+    "in the image."
+)
+
+
+class GLMOCRModel(MarkdownModel):
+    """Drives GLM-OCR, which transcribes a page image to full-page Markdown."""
+
+    default_model_name = "zai-org/GLM-OCR"
+    preferred_longest_image_dim = 1540
+
+    def __init__(self) -> None:
+        super().__init__(prompt=GLM_OCR_PROMPT)

--- a/src/paperscale/models/infinity_parser.py
+++ b/src/paperscale/models/infinity_parser.py
@@ -1,0 +1,59 @@
+"""Infinity-Parser2 Flash adapter: Qwen3.5-VL document model in doc2md mode.
+
+Infinity-Parser2-Flash (https://huggingface.co/infly/Infinity-Parser2-Flash) is a
+~2B Qwen3.5-VL-family document parser. Its native mode is doc2json (bounding-box
+JSON); paperscale instead drives it in *doc2md* mode by prompting it to emit
+Markdown, so parsing reuses the generic Markdown path. Selected with
+``--ocr-model infinity-parser2-flash``.
+
+The model is a Qwen3 reasoning model, so the adapter disables thinking at the
+vLLM server via the top-level ``chat_template_kwargs`` request key and also
+strips any stray ``<think>...</think>`` block defensively in :meth:`parse`.
+
+Serve it with vLLM >= ~0.20 on Python 3.13::
+
+    vllm serve infly/Infinity-Parser2-Flash --trust-remote-code \\
+        --reasoning-parser qwen3 --mm-encoder-tp-mode data \\
+        --mm-processor-cache-type shm --enable-prefix-caching
+
+In doc2md mode the response is Markdown with HTML tables and LaTeX equations.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+
+from paperscale.models.markdown import MarkdownModel
+from paperscale.prompts import PageResponse
+
+# Removes a stray reasoning block if the server's reasoning parser leaks one
+# through despite enable_thinking=False.
+_THINK_BLOCK = re.compile(r"<think>.*?</think>", re.DOTALL)
+
+
+class InfinityParser2FlashModel(MarkdownModel):
+    """Drives Infinity-Parser2-Flash in doc2md mode (Markdown + HTML tables)."""
+
+    default_model_name = "infly/Infinity-Parser2-Flash"
+    preferred_longest_image_dim = 1540
+
+    def __init__(self) -> None:
+        # doc2md mode: ask for Markdown instead of the model's default
+        # doc2json/bbox-JSON output.
+        super().__init__(prompt="Please transform the document's contents into Markdown format.")
+
+    def sampling_params(self) -> dict:
+        # Recommended decoding plus the Qwen3 thinking switch. The
+        # chat_template_kwargs key merges at the top level of the request (NOT
+        # under extra_body) and disables reasoning at the vLLM server.
+        return {"top_p": 1.0, "chat_template_kwargs": {"enable_thinking": False}}
+
+    def parse(self, content: str) -> PageResponse:
+        # Defensively drop any leaked reasoning block, then reuse the generic
+        # Markdown parse (code-fence strip + normalization).
+        content = _THINK_BLOCK.sub("", content)
+        result = super().parse(content)
+        # doc2md emits tables as HTML, so flag the page when one is present.
+        is_table = "<table" in (result.natural_text or "").lower()
+        return replace(result, is_table=is_table)

--- a/src/paperscale/models/qianfan.py
+++ b/src/paperscale/models/qianfan.py
@@ -15,10 +15,16 @@ the final ``</think>``.
 
 from __future__ import annotations
 
-import dataclasses
+import re
+from dataclasses import replace
 
 from paperscale.models.markdown import MarkdownModel
 from paperscale.prompts import PageResponse
+
+# A complete <think>...</think> reasoning block (only emitted when
+# enable_thinking=True, which paperscale never sets). Matched-pair only, so a
+# literal "</think>" transcribed from the page can't truncate real content.
+_THINK_BLOCK = re.compile(r"<think>.*?</think>", re.DOTALL)
 
 
 class QianfanOCRModel(MarkdownModel):
@@ -36,13 +42,12 @@ class QianfanOCRModel(MarkdownModel):
         return {"top_p": 1.0, "max_tokens": 12000}
 
     def parse(self, content: str) -> PageResponse:
-        # Defensive: drop any leading <think>...</think> reasoning block and keep
-        # only the answer after the last </think>. paperscale never sets
-        # enable_thinking, so this is normally a no-op.
-        if "</think>" in content:
-            content = content.rsplit("</think>", 1)[1]
+        # Defensive: drop any <think>...</think> reasoning block. paperscale never
+        # sets enable_thinking, so this is normally a no-op; matched-pair only, so a
+        # literal "</think>" in the page can't truncate the transcription.
+        content = _THINK_BLOCK.sub("", content)
         result = super().parse(content)
         # Qianfan returns tables as HTML, which paperscale accepts as-is. Recompute
         # is_table from the emitted Markdown rather than convert it.
         is_table = "<table" in (result.natural_text or "").lower()
-        return dataclasses.replace(result, is_table=is_table)
+        return replace(result, is_table=is_table)

--- a/src/paperscale/models/qianfan.py
+++ b/src/paperscale/models/qianfan.py
@@ -1,0 +1,48 @@
+"""Qianfan-OCR adapter: single image+text call, Markdown output.
+
+Qianfan-OCR (https://huggingface.co/baidu/Qianfan-OCR) is a ~4B document model
+pairing a Qianfan-ViT encoder with a Qwen3-4B decoder. It is served on vLLM as an
+``InternVLChatModel`` via ``--hf-overrides`` (see the serve command in the README);
+one image + text prompt yields clean reading-ordered Markdown with HTML tables and
+``$$ .. $$`` LaTeX. Selected with ``--ocr-model qianfan-ocr``.
+
+Parsing reuses the generic Markdown path, with one defensive twist: when
+``enable_thinking=True`` Qianfan first emits a ``<think>...</think>`` block carrying
+``<COORD_*>`` layout tokens before the answer. paperscale never enables thinking, so
+no block should appear, but :meth:`parse` strips one anyway and keeps the text after
+the final ``</think>``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from paperscale.models.markdown import MarkdownModel
+from paperscale.prompts import PageResponse
+
+
+class QianfanOCRModel(MarkdownModel):
+    """Drives Qianfan-OCR, which transcribes a page image to reading-ordered Markdown."""
+
+    default_model_name = "baidu/Qianfan-OCR"
+    preferred_longest_image_dim = 1540
+
+    def __init__(self) -> None:
+        super().__init__(prompt="Parse this document to Markdown.")
+
+    def sampling_params(self) -> dict:
+        # Raise max_tokens above the pipeline's 8000 default: Qianfan pages run long.
+        # Temperature stays pipeline-owned.
+        return {"top_p": 1.0, "max_tokens": 12000}
+
+    def parse(self, content: str) -> PageResponse:
+        # Defensive: drop any leading <think>...</think> reasoning block and keep
+        # only the answer after the last </think>. paperscale never sets
+        # enable_thinking, so this is normally a no-op.
+        if "</think>" in content:
+            content = content.rsplit("</think>", 1)[1]
+        result = super().parse(content)
+        # Qianfan returns tables as HTML, which paperscale accepts as-is. Recompute
+        # is_table from the emitted Markdown rather than convert it.
+        is_table = "<table" in (result.natural_text or "").lower()
+        return dataclasses.replace(result, is_table=is_table)

--- a/src/paperscale/models/surya.py
+++ b/src/paperscale/models/surya.py
@@ -57,7 +57,13 @@ SURYA_OCR_PROMPT = (
 # Section headers/titles become Markdown headings; the rest of a block's body is
 # already semantic HTML (<p>/<b>/<ol>/<table>/<math> …) that markdownify converts.
 _HEADING_LABELS = {"Section-Header", "Title"}
-_DIAGRAM_LABELS = {"Figure", "Image", "Diagram"}
+_DIAGRAM_LABELS = ("Figure", "Image", "Diagram")
+
+# Table/diagram page flags, read from the block labels. Tolerant of the model's
+# attribute quoting (single or double quotes, optional surrounding whitespace) so a
+# correctly-transcribed page isn't mis-flagged on a quoting change.
+_TABLE_LABEL_RE = re.compile(r"""data-label\s*=\s*["']Table["']""")
+_DIAGRAM_LABEL_RE = re.compile(r"""data-label\s*=\s*["'](?:%s)["']""" % "|".join(_DIAGRAM_LABELS))
 
 # Collapse runs of 3+ newlines (markdownify's block spacing) down to a blank line.
 _EXCESS_BLANKS = re.compile(r"\n{3,}")
@@ -138,8 +144,8 @@ class Surya2Model(OCRModel):
         markdown = _EXCESS_BLANKS.sub("\n\n", markdown).strip()
 
         # Label markers are the cheapest reliable signal for table/diagram pages.
-        is_table = 'data-label="Table"' in content
-        is_diagram = any(f'data-label="{label}"' in content for label in _DIAGRAM_LABELS)
+        is_table = bool(_TABLE_LABEL_RE.search(content))
+        is_diagram = bool(_DIAGRAM_LABEL_RE.search(content))
 
         return PageResponse(
             primary_language=None,

--- a/src/paperscale/models/surya.py
+++ b/src/paperscale/models/surya.py
@@ -1,0 +1,151 @@
+"""Surya OCR 2 adapter: reading-ordered *layout-HTML* output, Markdown parse.
+
+Surya OCR 2 (https://huggingface.co/datalab-to/surya-ocr-2) is a ~0.65B
+Qwen3.5-style vision-language model (``Qwen3_5ForConditionalGeneration``). Unlike
+the Markdown-emitting adapters, its full-page-OCR mode returns one **layout-HTML**
+document per page: a flat sequence of ``<div>`` blocks *in reading order*, each
+carrying ``data-bbox`` (normalized 0-1000 coordinates) and a ``data-label``
+(``Text``, ``Section-Header``, ``List-Group``, ``Table``, ``Figure``,
+``Image`` …). Equations are embedded as ``<math>`` (KaTeX LaTeX) and tables as
+real HTML ``<table>`` markup (with ``rowspan``/``colspan``). Selected with
+``--ocr-model surya2``.
+
+One VLM call produces the whole page — the layout pre-stage that ``surya`` runs
+locally is optional and is skipped here, since the high-accuracy-bbox prompt makes
+the model emit labelled blocks directly. Serve it on a recent vLLM (v0.20.0+) with
+native ``qwen3_5`` support; avoid v0.18.0, which predates the architecture.
+
+``parse`` walks the layout-HTML once with a tiny :class:`markdownify`
+``MarkdownConverter`` subclass that maps each labelled ``<div>`` to its Markdown
+equivalent (headings, list items, paragraphs), rewrites ``<math>`` into
+paperscale's backslash-delimited LaTeX, and lets markdownify's built-in handlers
+turn ``<table>`` and inline emphasis into Markdown.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+
+from markdownify import MarkdownConverter
+
+from paperscale.models.base import OCRModel
+from paperscale.prompts import PageResponse
+
+_TAG = re.compile(r"<[^>]+>")
+
+
+def _strip_tags(content: str) -> str:
+    """Last-resort plain-text fallback when HTML conversion fails.
+
+    A degenerate response (e.g. a repetition loop nesting ``<div>`` thousands
+    deep) can overflow markdownify's recursive walk; a regex strip never recurses.
+    """
+    return html.unescape(_TAG.sub(" ", content))
+
+# Surya's full-page-OCR instruction. This is the high-accuracy-bbox prompt from
+# the surya-ocr package (surya/inference/prompts.py, HIGH_ACCURACY_BBOX_PROMPT);
+# it is what drives the labelled ``<div data-label=… data-bbox=…>`` layout-HTML
+# output this adapter parses. The sibling block/layout prompts flip the model into
+# block-OCR or layout-JSON mode, so this exact string matters.
+SURYA_OCR_PROMPT = (
+    "OCR this image to HTML. Each block is a div with data-label and data-bbox "
+    "(x0 y0 x1 y1, normalized 0-1000)."
+)
+
+# Surya's block ``data-label`` values (its LAYOUT_LABEL_SET; note the hyphens).
+# Section headers/titles become Markdown headings; the rest of a block's body is
+# already semantic HTML (<p>/<b>/<ol>/<table>/<math> …) that markdownify converts.
+_HEADING_LABELS = {"Section-Header", "Title"}
+_DIAGRAM_LABELS = {"Figure", "Image", "Diagram"}
+
+# Collapse runs of 3+ newlines (markdownify's block spacing) down to a blank line.
+_EXCESS_BLANKS = re.compile(r"\n{3,}")
+
+# A list item whose text already opens with its own enumerator ("1.", "(a)", "iv.").
+# Surya numbers items inline, so we keep that marker instead of adding another.
+_INLINE_LIST_MARKER = re.compile(r"^\(?(?:\d{1,3}|[a-zA-Z]|[ivxlcdm]{1,4})[.)]\s")
+
+
+class _SuryaHTMLConverter(MarkdownConverter):
+    """markdownify converter for Surya's labelled layout-HTML.
+
+    Only the model-specific tags need custom handling: ``<div>`` (read its
+    ``data-label`` to pick a Markdown shape) and ``<math>`` (paperscale LaTeX
+    delimiters). Tables and inline emphasis fall through to markdownify's
+    built-ins.
+    """
+
+    def convert_div(self, el, text, parent_tags):
+        # data-bbox/data-label are layout metadata, not content. Surya already
+        # emits semantic HTML inside each block, so markdownify's built-ins handle
+        # the body; we only special-case section headers, which the model wraps in
+        # <b><u> rather than <hN> — emit them as a Markdown heading from plain text.
+        label = (el.get("data-label") or "").strip()
+        if label in _HEADING_LABELS:
+            heading = el.get_text(" ", strip=True)
+            return f"\n# {heading}\n\n" if heading else ""
+        body = text.strip()
+        return f"{body}\n\n" if body else ""
+
+    def convert_li(self, el, text, parent_tags):
+        # Surya frequently numbers list items *inline* (e.g. "1. The Plaintiff…").
+        # Letting markdownify prepend its own marker then yields "1. 1. …", so when
+        # the item text already opens with an enumerator, emit it as a plain line;
+        # otherwise defer to markdownify's normal bullet/number handling.
+        line = text.strip()
+        if _INLINE_LIST_MARKER.match(line):
+            return f"{line}\n"
+        return super().convert_li(el, text, parent_tags)  # type: ignore  (markdownify resolves convert_* dynamically)
+
+    def convert_math(self, el, text, parent_tags):
+        # KaTeX LaTeX → paperscale's backslash-delimited convention. ``display``
+        # math becomes a block ``\[ … \]``; everything else is inline ``\( … \)``.
+        latex = text.strip()
+        if not latex:
+            return ""
+        if (el.get("display") or "").lower() == "block":
+            return f"\\[ {latex} \\]"
+        return f"\\( {latex} \\)"
+
+
+class Surya2Model(OCRModel):
+    """Drives Surya OCR 2, which returns reading-ordered layout-HTML per page."""
+
+    default_model_name = "datalab-to/surya-ocr-2"
+    preferred_longest_image_dim = 1540
+
+    def build_messages(self, image_base64: str) -> list[dict]:
+        return [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": SURYA_OCR_PROMPT},
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{image_base64}"}},
+                ],
+            }
+        ]
+
+    def parse(self, content: str) -> PageResponse:
+        # One pass over the whole layout-HTML; then squeeze excess blank lines.
+        # A degenerate model response (a repetition loop nesting <div>s thousands
+        # deep) can overflow markdownify's recursive walk — fall back to a
+        # tag-stripped best-effort so the page is retried/verified, never crashed.
+        try:
+            markdown = _SuryaHTMLConverter().convert(content)
+        except Exception:
+            markdown = _strip_tags(content)
+        markdown = _EXCESS_BLANKS.sub("\n\n", markdown).strip()
+
+        # Label markers are the cheapest reliable signal for table/diagram pages.
+        is_table = 'data-label="Table"' in content
+        is_diagram = any(f'data-label="{label}"' in content for label in _DIAGRAM_LABELS)
+
+        return PageResponse(
+            primary_language=None,
+            is_rotation_valid=True,
+            rotation_correction=0,
+            is_table=is_table,
+            is_diagram=is_diagram,
+            natural_text=markdown or None,
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,12 +5,17 @@ import unittest
 from paperscale.models import (
     DEFAULT_MODEL,
     MODEL_REGISTRY,
+    GLMOCRModel,
+    InfinityParser2FlashModel,
     LightOnOCRModel,
     LightOnOCRSoupModel,
     MarkdownModel,
     OlmOCRModel,
+    QianfanOCRModel,
+    Surya2Model,
     build_ocr_model,
 )
+from paperscale.models.glmocr import GLM_OCR_PROMPT
 from paperscale.models.markdown import _strip_code_fence
 from paperscale.prompts import PageResponse
 
@@ -24,9 +29,25 @@ class RegistryTests(unittest.TestCase):
         self.assertIsInstance(build_ocr_model("olmocr"), OlmOCRModel)
         self.assertIsInstance(build_ocr_model("lightonocr2"), LightOnOCRModel)
         self.assertIsInstance(build_ocr_model("lightonocr2-soup"), LightOnOCRSoupModel)
+        self.assertIsInstance(build_ocr_model("glm-ocr"), GLMOCRModel)
+        self.assertIsInstance(build_ocr_model("qianfan-ocr"), QianfanOCRModel)
+        self.assertIsInstance(build_ocr_model("infinity-parser2-flash"), InfinityParser2FlashModel)
+        self.assertIsInstance(build_ocr_model("surya2"), Surya2Model)
 
     def test_registry_contents(self):
-        self.assertEqual(set(MODEL_REGISTRY), {"markdown", "olmocr", "lightonocr2", "lightonocr2-soup"})
+        self.assertEqual(
+            set(MODEL_REGISTRY),
+            {
+                "markdown",
+                "olmocr",
+                "lightonocr2",
+                "lightonocr2-soup",
+                "glm-ocr",
+                "qianfan-ocr",
+                "infinity-parser2-flash",
+                "surya2",
+            },
+        )
 
     def test_unknown_model_raises_with_choices(self):
         with self.assertRaises(ValueError) as ctx:
@@ -188,6 +209,204 @@ class InterfaceDefaultsTests(unittest.TestCase):
         model = OlmOCRModel()
         self.assertEqual(model.sampling_params(), {})
         self.assertEqual(model.preferred_longest_image_dim, 1288)
+
+
+class GLMOCRModelTests(unittest.TestCase):
+    def setUp(self):
+        self.model = GLMOCRModel()
+
+    def test_recipe(self):
+        self.assertEqual(self.model.default_model_name, "zai-org/GLM-OCR")
+        self.assertEqual(self.model.preferred_longest_image_dim, 1540)
+        # GLM-OCR uses default decoding; nothing merged into the request and
+        # temperature stays pipeline-owned.
+        self.assertEqual(self.model.sampling_params(), {})
+        self.assertIsNone(self.model.guided_regex())
+
+    def test_build_messages_has_prompt_and_image(self):
+        messages = self.model.build_messages("QUJD")
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["role"], "user")
+        parts = messages[0]["content"]
+        self.assertEqual(parts[0]["type"], "text")
+        self.assertEqual(parts[0]["text"], GLM_OCR_PROMPT)
+        self.assertEqual(parts[1]["type"], "image_url")
+        self.assertEqual(parts[1]["image_url"]["url"], "data:image/png;base64,QUJD")
+
+    def test_parse_passes_markdown_through(self):
+        page = self.model.parse("# Heading\n\nBody text.")
+        self.assertEqual(page.natural_text, "# Heading\n\nBody text.")
+        self.assertIsNone(page.primary_language)
+        self.assertTrue(page.is_rotation_valid)
+        self.assertEqual(page.rotation_correction, 0)
+        self.assertFalse(page.is_table)
+        self.assertFalse(page.is_diagram)
+
+    def test_parse_strips_wrapping_code_fence(self):
+        page = self.model.parse("```markdown\n# Heading\n\nBody.\n```")
+        self.assertEqual(page.natural_text, "# Heading\n\nBody.")
+
+    def test_parse_empty_page_is_none(self):
+        self.assertIsNone(self.model.parse("   ").natural_text)
+
+
+class QianfanOCRModelTests(unittest.TestCase):
+    def setUp(self):
+        self.model = QianfanOCRModel()
+
+    def test_recipe(self):
+        self.assertEqual(self.model.default_model_name, "baidu/Qianfan-OCR")
+        self.assertEqual(self.model.preferred_longest_image_dim, 1540)
+        self.assertEqual(self.model.sampling_params(), {"top_p": 1.0, "max_tokens": 12000})
+        self.assertIsNone(self.model.guided_regex())
+
+    def test_build_messages_text_and_image(self):
+        messages = self.model.build_messages("BASE64DATA")
+        self.assertEqual(len(messages), 1)
+        content = messages[0]["content"]
+        self.assertEqual(content[0], {"type": "text", "text": "Parse this document to Markdown."})
+        self.assertEqual(
+            content[1],
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,BASE64DATA"}},
+        )
+
+    def test_parse_passes_clean_markdown_through(self):
+        result = self.model.parse("# Title\n\nHello world")
+        self.assertEqual(result.natural_text, "# Title\n\nHello world")
+        self.assertIsInstance(result, PageResponse)
+        self.assertTrue(result.is_rotation_valid)
+        self.assertEqual(result.rotation_correction, 0)
+        self.assertFalse(result.is_table)
+        self.assertFalse(result.is_diagram)
+        self.assertIsNone(result.primary_language)
+
+    def test_parse_strips_leading_think_block(self):
+        result = self.model.parse("<think>layout...</think>\n# Title")
+        self.assertEqual(result.natural_text, "# Title")
+
+    def test_parse_detects_html_table(self):
+        result = self.model.parse("Intro\n<table><tr><td>a</td></tr></table>")
+        self.assertTrue(result.is_table)
+
+    def test_parse_empty_page_returns_none(self):
+        self.assertIsNone(self.model.parse("").natural_text)
+
+
+class InfinityParser2FlashModelTests(unittest.TestCase):
+    def setUp(self):
+        self.model = InfinityParser2FlashModel()
+
+    def test_recipe(self):
+        self.assertEqual(self.model.default_model_name, "infly/Infinity-Parser2-Flash")
+        self.assertEqual(self.model.preferred_longest_image_dim, 1540)
+        # top-level chat_template_kwargs disables Qwen3 thinking (not extra_body)
+        self.assertEqual(
+            self.model.sampling_params(),
+            {"top_p": 1.0, "chat_template_kwargs": {"enable_thinking": False}},
+        )
+
+    def test_build_messages_doc2md_prompt_and_image(self):
+        messages = self.model.build_messages("BASE64DATA")
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["role"], "user")
+        text_part, image_part = messages[0]["content"]
+        self.assertEqual(
+            text_part,
+            {"type": "text", "text": "Please transform the document's contents into Markdown format."},
+        )
+        self.assertEqual(
+            image_part,
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,BASE64DATA"}},
+        )
+
+    def test_parse_strips_think_block_and_code_fence(self):
+        raw = "<think>plan the layout</think>```markdown\n# Heading\n\nBody text\n```"
+        result = self.model.parse(raw)
+        self.assertEqual(result.natural_text, "# Heading\n\nBody text")
+        self.assertNotIn("<think>", result.natural_text)
+        self.assertNotIn("```", result.natural_text)
+        self.assertFalse(result.is_table)
+        self.assertTrue(result.is_rotation_valid)
+        self.assertEqual(result.rotation_correction, 0)
+
+    def test_parse_detects_html_table(self):
+        result = self.model.parse("<table><tr><td>cell</td></tr></table>")
+        self.assertTrue(result.is_table)
+
+    def test_parse_empty_after_think_block_is_none(self):
+        result = self.model.parse("<think>only reasoning, no page text</think>")
+        self.assertIsNone(result.natural_text)
+        self.assertFalse(result.is_table)
+
+
+# Captured Surya OCR 2 layout-HTML (real label names + the model's inner markup):
+# a Section-Header wrapped in <b><u>, a Text block with an inline <math>, an HTML
+# <table>, and a List-Group (<ol><li>). data-bbox is the model's "x0 y0 x1 y1" form.
+_SAMPLE_LAYOUT_HTML = (
+    '<div data-bbox="474 376 601 394" data-label="Section-Header">'
+    "<p><b><u>Results and Discussion</u></b></p></div>"
+    '<div data-bbox="151 186 889 271" data-label="Text">'
+    "<p>The relation <math>E = mc^2</math> held across every trial.</p></div>"
+    '<div data-bbox="151 439 919 600" data-label="Table">'
+    "<table><tr><th>Name</th><th>Score</th></tr>"
+    "<tr><td>Alpha</td><td>0.91</td></tr></table></div>"
+    '<div data-bbox="151 610 900 700" data-label="List-Group">'
+    "<ol><li>First finding</li></ol></div>"
+)
+
+
+class Surya2ModelTests(unittest.TestCase):
+    def setUp(self):
+        self.model = Surya2Model()
+
+    def test_recipe(self):
+        self.assertEqual(self.model.default_model_name, "datalab-to/surya-ocr-2")
+        self.assertEqual(self.model.preferred_longest_image_dim, 1540)
+        self.assertEqual(self.model.sampling_params(), {})
+        self.assertIsNone(self.model.guided_regex())
+
+    def test_build_messages(self):
+        messages = self.model.build_messages("QUJD")
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["role"], "user")
+        content = messages[0]["content"]
+        self.assertEqual(content[0]["type"], "text")
+        self.assertIn("OCR this image to HTML", content[0]["text"])
+        self.assertEqual(content[1]["image_url"]["url"], "data:image/png;base64,QUJD")
+
+    def test_parse_layout_html(self):
+        result = self.model.parse(_SAMPLE_LAYOUT_HTML)
+        self.assertIsInstance(result, PageResponse)
+        text = result.natural_text
+        self.assertIsNotNone(text)
+        # SectionHeader -> Markdown heading.
+        self.assertIn("# Results and Discussion", text)
+        # <math> -> paperscale inline LaTeX delimiters.
+        self.assertIn("\\( E = mc^2 \\)", text)
+        # HTML table -> Markdown table (header cells preserved, pipe delimiters).
+        self.assertIn("Name", text)
+        self.assertIn("Score", text)
+        self.assertIn("|", text)
+        # List-Group (<ol><li>) -> Markdown list item.
+        self.assertIn("First finding", text)
+        # Flags from data-label markers.
+        self.assertTrue(result.is_table)
+        self.assertFalse(result.is_diagram)
+        self.assertTrue(result.is_rotation_valid)
+        self.assertEqual(result.rotation_correction, 0)
+
+    def test_parse_empty(self):
+        result = self.model.parse("")
+        self.assertIsNone(result.natural_text)
+        self.assertFalse(result.is_table)
+        self.assertFalse(result.is_diagram)
+
+    def test_parse_pathological_nesting_does_not_raise(self):
+        # A repetition-loop response can nest <div>s thousands deep and overflow
+        # markdownify's recursive walk; parse() must degrade, not raise.
+        evil = "<div>" * 2000 + "x" + "</div>" * 2000
+        result = self.model.parse(evil)  # must not raise RecursionError
+        self.assertIsInstance(result, PageResponse)
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -284,6 +284,12 @@ class QianfanOCRModelTests(unittest.TestCase):
         result = self.model.parse("<think>layout...</think>\n# Title")
         self.assertEqual(result.natural_text, "# Title")
 
+    def test_parse_keeps_content_before_stray_think_close(self):
+        # A literal "</think>" in the page (no opening tag) must NOT truncate the
+        # transcription — matched-pair stripping only.
+        result = self.model.parse("real content </think> tail")
+        self.assertEqual(result.natural_text, "real content </think> tail")
+
     def test_parse_detects_html_table(self):
         result = self.model.parse("Intro\n<table><tr><td>a</td></tr></table>")
         self.assertTrue(result.is_table)
@@ -407,6 +413,13 @@ class Surya2ModelTests(unittest.TestCase):
         evil = "<div>" * 2000 + "x" + "</div>" * 2000
         result = self.model.parse(evil)  # must not raise RecursionError
         self.assertIsInstance(result, PageResponse)
+
+    def test_parse_flags_tolerate_attribute_quoting(self):
+        # is_table/is_diagram must not depend on the model's quoting style.
+        single = "<div data-label='Table'><table><tr><td>x</td></tr></table></div>"
+        self.assertTrue(self.model.parse(single).is_table)
+        spaced = "<div data-label = \"Figure\">fig</div>"
+        self.assertTrue(self.model.parse(spaced).is_diagram)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds four OCR-model adapters, each selectable with `--ocr-model`:

| `--ocr-model` | Repo | Adapter | Serving (vLLM) |
|---|---|---|---|
| `glm-ocr` | `zai-org/GLM-OCR` | `MarkdownModel` subclass, single-call full-page | native `glm_ocr` (PR #33005) |
| `qianfan-ocr` | `baidu/Qianfan-OCR` | `MarkdownModel` + `<think>` strip | `--trust-remote-code --hf-overrides '{"architectures":["InternVLChatModel"]}'` |
| `infinity-parser2-flash` | `infly/Infinity-Parser2-Flash` | doc2md mode, `<think>` strip | `--trust-remote-code --reasoning-parser qwen3` (py3.13) |
| `surya2` | `datalab-to/surya-ocr-2` | `OCRModel` + markdownify layout-HTML→Markdown | native `qwen3_5` |

`markdownify` is added as a dependency (used by the Surya layout-HTML parse). The registry, unit tests, and README are updated.

### Excluded (by design)
**PaddleOCR-VL** and **Falcon-OCR** were researched and excluded — both require a separate layout/detection stage (multi-stage) that doesn't fit paperscale's single-image → one chat call → one `PageResponse` contract.

## Implementation notes
- `infinity-parser2-flash` disables Qwen3 reasoning via a **top-level** `chat_template_kwargs` key (paperscale POSTs raw JSON; `extra_body` is an OpenAI-SDK-only construct).
- `surya2` parses Surya's reading-ordered layout-HTML: `Section-Header`→`#`, inline-numbered lists handled without double-numbering, HTML tables via markdownify, `<math>`→`\( \)`/`\[ \]`. `parse()` degrades to a tag-stripped fallback (never raises) on degenerate, deeply-nested output.

## Validation
- **Unit:** 100 tests pass; ruff clean; pyrefly 0 errors.
- **Live smoke test:** 50 PDFs per model (~599 pages each) against vLLM 0.22.1 on an RTX 3090 — **0 page failures** for all four. Output Markdown spot-checked (headings, lists, tables, no reasoning-token leakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)