### PR TITLE
feat(models): add Unlimited-OCR adapter

### DIFF
--- a/src/paperscale/models/__init__.py
+++ b/src/paperscale/models/__init__.py
@@ -14,6 +14,7 @@ from paperscale.models.markdown import MarkdownModel
 from paperscale.models.olmocr import OlmOCRModel
 from paperscale.models.qianfan import QianfanOCRModel
 from paperscale.models.surya import Surya2Model
+from paperscale.models.unlimited_ocr import UnlimitedOCRModel
 
 DEFAULT_MODEL = "markdown"
 
@@ -26,6 +27,7 @@ MODEL_REGISTRY: dict[str, type[OCRModel]] = {
     "qianfan-ocr": QianfanOCRModel,
     "infinity-parser2-flash": InfinityParser2FlashModel,
     "surya2": Surya2Model,
+    "unlimited-ocr": UnlimitedOCRModel,
 }
 
 
@@ -49,6 +51,7 @@ __all__ = [
     "QianfanOCRModel",
     "InfinityParser2FlashModel",
     "Surya2Model",
+    "UnlimitedOCRModel",
     "MODEL_REGISTRY",
     "DEFAULT_MODEL",
     "build_ocr_model",

--- a/src/paperscale/models/unlimited_ocr.py
+++ b/src/paperscale/models/unlimited_ocr.py
@@ -1,0 +1,66 @@
+"""Unlimited-OCR adapter: Baidu's DeepSeek-OCR successor, full-page Markdown.
+
+Unlimited-OCR (https://huggingface.co/baidu/Unlimited-OCR) is a ~3.3B
+vision-language model from Baidu that pushes DeepSeek-OCR one step further
+("one-shot long-horizon parsing"). One page image plus the vendor prompt
+``<image>document parsing.`` yields the page as Markdown with embedded
+grounding tokens; :meth:`parse` unwraps ``<|ref|>text<|/ref|>`` and drops
+``<|det|>[[boxes]]<|/det|>`` to leave clean Markdown. Selected with
+``--ocr-model unlimited-ocr``.
+
+vLLM serving (recipe: https://recipes.vllm.ai/baidu/Unlimited-OCR, needs
+vLLM >= 0.25.0 / the ``vllm/vllm-openai:unlimited-ocr`` image)::
+
+    vllm serve baidu/Unlimited-OCR --trust-remote-code \
+        --logits_processors vllm.model_executor.models.unlimited_ocr:NGramPerReqLogitsProcessor \
+        --no-enable-prefix-caching --mm-processor-cache-gb 0
+
+The custom logits processor is mandatory (long documents loop on coordinate
+tokens without it); this adapter passes its per-request args (``ngram_size=35``,
+``window_size=128``) via ``vllm_xargs``. The prompt text must begin with a
+literal ``<image>`` tag and requests must set ``skip_special_tokens=false`` —
+missing either produces empty output. Single-image requests use the model's
+crop ("gundam") mode with base_size=1024, so pages render at 1024 px.
+"""
+
+from __future__ import annotations
+
+import re
+
+from paperscale.models.markdown import MarkdownModel
+from paperscale.prompts import PageResponse
+
+# Vendor prompt; the literal <image> prefix is required by the vLLM chat path.
+UNLIMITED_OCR_PROMPT = "<image>document parsing."
+
+# Grounding output: <|ref|>text<|/ref|> optionally followed by a
+# <|det|>[[x1,y1,x2,y2],...]<|/det|> coordinate block. Keep the text, drop the boxes.
+_REF = re.compile(r"<\|ref\|>(.*?)<\|/ref\|>", re.DOTALL)
+_DET = re.compile(r"<\|det\|>.*?<\|/det\|>", re.DOTALL)
+# skip_special_tokens=false leaves structural specials (e.g. end-of-sentence) in the text.
+_SPECIAL = re.compile(r"<[|｜][^<>]*?[|｜]>")
+
+
+class UnlimitedOCRModel(MarkdownModel):
+    """Drives Unlimited-OCR, which emits page Markdown with grounding tokens."""
+
+    default_model_name = "baidu/Unlimited-OCR"
+    preferred_longest_image_dim = 1024
+
+    def __init__(self) -> None:
+        super().__init__(prompt=UNLIMITED_OCR_PROMPT)
+
+    def sampling_params(self) -> dict:
+        # skip_special_tokens=false is required for non-empty output; the ngram
+        # anti-loop processor args ride along per request via vllm_xargs.
+        # Temperature stays pipeline-owned.
+        return {
+            "skip_special_tokens": False,
+            "vllm_xargs": {"ngram_size": 35, "window_size": 128},
+        }
+
+    def parse(self, content: str) -> PageResponse:
+        content = _REF.sub(r"\1", content)
+        content = _DET.sub("", content)
+        content = _SPECIAL.sub("", content)
+        return super().parse(content)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,7 @@ from paperscale.models import (
     OlmOCRModel,
     QianfanOCRModel,
     Surya2Model,
+    UnlimitedOCRModel,
     build_ocr_model,
 )
 from paperscale.models.glmocr import GLM_OCR_PROMPT
@@ -33,6 +34,7 @@ class RegistryTests(unittest.TestCase):
         self.assertIsInstance(build_ocr_model("qianfan-ocr"), QianfanOCRModel)
         self.assertIsInstance(build_ocr_model("infinity-parser2-flash"), InfinityParser2FlashModel)
         self.assertIsInstance(build_ocr_model("surya2"), Surya2Model)
+        self.assertIsInstance(build_ocr_model("unlimited-ocr"), UnlimitedOCRModel)
 
     def test_registry_contents(self):
         self.assertEqual(
@@ -46,6 +48,7 @@ class RegistryTests(unittest.TestCase):
                 "qianfan-ocr",
                 "infinity-parser2-flash",
                 "surya2",
+                "unlimited-ocr",
             },
         )
 
@@ -420,6 +423,55 @@ class Surya2ModelTests(unittest.TestCase):
         self.assertTrue(self.model.parse(single).is_table)
         spaced = "<div data-label = \"Figure\">fig</div>"
         self.assertTrue(self.model.parse(spaced).is_diagram)
+
+
+class UnlimitedOCRModelTests(unittest.TestCase):
+    def setUp(self):
+        self.model = UnlimitedOCRModel()
+
+    def test_recipe(self):
+        self.assertEqual(self.model.default_model_name, "baidu/Unlimited-OCR")
+        self.assertEqual(self.model.preferred_longest_image_dim, 1024)
+        # skip_special_tokens=false and the ngram anti-loop processor args are
+        # required by the vLLM recipe; temperature stays pipeline-owned.
+        self.assertEqual(
+            self.model.sampling_params(),
+            {"skip_special_tokens": False, "vllm_xargs": {"ngram_size": 35, "window_size": 128}},
+        )
+        self.assertIsNone(self.model.guided_regex())
+
+    def test_build_messages_has_image_prefixed_prompt(self):
+        messages = self.model.build_messages("QUJD")
+        self.assertEqual(len(messages), 1)
+        text_part, image_part = messages[0]["content"]
+        # The literal <image> prefix is mandatory; without it output is empty.
+        self.assertEqual(text_part, {"type": "text", "text": "<image>document parsing."})
+        self.assertEqual(image_part["image_url"]["url"], "data:image/png;base64,QUJD")
+
+    def test_parse_unwraps_ref_and_drops_det(self):
+        raw = (
+            "<|ref|># Heading<|/ref|><|det|>[[10,20,900,60]]<|/det|>\n\n"
+            "Body text with <|ref|>a grounded span<|/ref|><|det|>[[1,2,3,4]]<|/det|> inline."
+        )
+        result = self.model.parse(raw)
+        self.assertEqual(
+            result.natural_text,
+            "# Heading\n\nBody text with a grounded span inline.",
+        )
+        self.assertTrue(result.is_rotation_valid)
+        self.assertEqual(result.rotation_correction, 0)
+
+    def test_parse_strips_leftover_special_tokens(self):
+        # skip_special_tokens=false can leave structural specials in the text.
+        result = self.model.parse("Hello world<｜end▁of▁sentence｜>")
+        self.assertEqual(result.natural_text, "Hello world")
+
+    def test_parse_plain_markdown_passes_through(self):
+        self.assertEqual(self.model.parse("# Title\n\ntext").natural_text, "# Title\n\ntext")
+
+    def test_parse_empty_page_is_none(self):
+        self.assertIsNone(self.model.parse("").natural_text)
+        self.assertIsNone(self.model.parse("<|ref|><|/ref|><|det|>[[0,0,0,0]]<|/det|>").natural_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add **baidu/Unlimited-OCR** (Baidu's DeepSeek-OCR successor, ~3.3B VLM) as `--ocr-model unlimited-ocr`
- Vendor-verbatim prompt `<image>document parsing.` — the literal `<image>` prefix is required on the vLLM path (empty output without it)
- `parse` unwraps `<|ref|>text<|/ref|>`, drops `<|det|>[[boxes]]<|/det|>` coordinate blocks, and strips leftover special tokens (requests must run with `skip_special_tokens: false`), then reuses the generic Markdown path
- `sampling_params()` sends `skip_special_tokens: false` + `vllm_xargs: {ngram_size: 35, window_size: 128}` for the mandatory `NGramPerReqLogitsProcessor` (long documents loop on coordinate tokens without it); temperature stays pipeline-owned
- Pages render at 1024 px (model's base/gundam `base_size`)
- Serving requirements recorded in the module docstring: vLLM ≥ 0.25.0, `--trust-remote-code --logits_processors vllm.model_executor.models.unlimited_ocr:NGramPerReqLogitsProcessor --no-enable-prefix-caching --mm-processor-cache-gb 0`

## Testing
- `poetry run pytest -q`: 108 passed (new tests: registry, `<image>`-prefixed message shape, ref-unwrap/det-drop parsing, special-token stripping, empty/grounding-only pages)
- Live smoke test on vLLM 0.25.1 (RTX 3090): **599 pages / 50 legal PDFs, 0 failed**, ~1465 output tok/s, zero leaked grounding/special tokens in the emitted Markdown; the one doc with no Markdown is the known blank-render corpus doc, not the adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)