### PR TITLE
feat: reference-free OCR-model evaluation (paperscale evaluate)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -402,6 +402,23 @@ files = [
 ]
 
 [[package]]
+name = "langcodes"
+version = "3.5.1"
+description = "Tools for labeling human languages with IETF language tags"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "langcodes-3.5.1-py3-none-any.whl", hash = "sha256:b6a9c25c603804e2d169165091d0cdb23934610524a21d226e4f463e8e958a72"},
+    {file = "langcodes-3.5.1.tar.gz", hash = "sha256:40bff315e01b01d11c2ae3928dd4f5cbd74dd38f9bd912c12b9a3606c143f731"},
+]
+
+[package.extras]
+build = ["build", "twine"]
+data = ["language-data (>=1.2)"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "lingua-language-detector"
 version = "2.2.0"
 description = "An accurate natural language detection library, suitable for short text and mixed-language text"
@@ -437,6 +454,18 @@ files = [
 
 [package.extras]
 test = ["pytest (==9.0.1)"]
+
+[[package]]
+name = "locate"
+version = "1.1.1"
+description = "Locate the file location of your current running script."
+optional = false
+python-versions = ">=3.4"
+groups = ["main"]
+files = [
+    {file = "locate-1.1.1-py3-none-any.whl", hash = "sha256:9e5e2f3516639240f4d975c08e95ae6a24ff4dd63d228f927541cdec30105755"},
+    {file = "locate-1.1.1.tar.gz", hash = "sha256:432750f5b7e89f8c99942ca7d8722ccd1e7954b20e6a973027fccb6cc00af857"},
+]
 
 [[package]]
 name = "lxml"
@@ -589,6 +618,31 @@ html5 = ["html5lib"]
 htmlsoup = ["BeautifulSoup4"]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"tui\""
+files = [
+    {file = "markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"},
+    {file = "markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "markdown-it-pyrs", "mistletoe (>=1.0,<2.0)", "mistune (>=3.0,<4.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins (>=0.5.0)"]
+profiling = ["gprof2dot"]
+rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme (>=1.0,<2.0)", "sphinx-copybutton", "sphinx-design"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "pytest-timeout", "requests"]
+
+[[package]]
 name = "markdownify"
 version = "1.2.2"
 description = "Convert HTML to markdown."
@@ -603,6 +657,95 @@ files = [
 [package.dependencies]
 beautifulsoup4 = ">=4.9,<5"
 six = ">=1.15,<2"
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"tui\""
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.1"
+description = "MessagePack serializer"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "msgpack-1.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8c7b398c56ff125feae96c2737abfec5595f1fa0aa186df60c56040b8accb95c"},
+    {file = "msgpack-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1548006a91aa93c5da81f3bdcebc1a0d10cea2d25969754fbe848da622b2b895"},
+    {file = "msgpack-1.2.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dabedcd0f23559f3596428c6589c1cd8c6eaed3a0d720795b07b0225d769203"},
+    {file = "msgpack-1.2.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83efa1c898e0fc5380fc0cabbf75164c52e3b5cbb45973710d75821928380c73"},
+    {file = "msgpack-1.2.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01e2dd6c9b19d333a00282330cc8a73d38d8dabc306dc5b42cd668c3ac82e833"},
+    {file = "msgpack-1.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:350cb813d0af6e65d2f7ef0d729f7ff5be5a8bce03665892f43e5883d4ecc1b8"},
+    {file = "msgpack-1.2.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ee1d9ed27d0497b848923746cf762ed2e7db24f4be7eec8e5cbe8c766aa707b7"},
+    {file = "msgpack-1.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:633727297ed063441fd1cda2288865487f33ad14eeb8831afb5f0c396a62cfce"},
+    {file = "msgpack-1.2.1-cp310-cp310-win32.whl", hash = "sha256:298872ecf9e61950f1c6af4ca969b859ee91783bb920ef6e6172697d0c8aad74"},
+    {file = "msgpack-1.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:2ff164c1b0bcb740b073b99e945234d0212852fa378e44a208c425379140dbeb"},
+    {file = "msgpack-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:29a3f6e9667868429d8240dfd063ea5ffdc1321c13d783aa23827a38de0dcb22"},
+    {file = "msgpack-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aded5bdf32609dc7987a49bbbd15a8ef096193f96dd8bbeb791de729e650acf5"},
+    {file = "msgpack-1.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:146ee4e9ce80b365c6d4c47073da9da7bcec473e58194ceee5dd7620ace77e06"},
+    {file = "msgpack-1.2.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a28d076ca7c82b9c8728ad90b7147489449557038bed50e4241eb832395169b4"},
+    {file = "msgpack-1.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7d31c0ac0c640f877804c67cb2bc9f4e23dc2db97e96c2e67fa27d38283b41f8"},
+    {file = "msgpack-1.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ff92d7feeaf5bc26c51495b69e2f99ed97ab79346fb6555f44be7dd2ac6503b"},
+    {file = "msgpack-1.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:779197a6513bab3c3632265e3d0f7cb3227e62510841a6f34f1eaa37efbb345e"},
+    {file = "msgpack-1.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:67f6dd22fa72a93752643f07889796d62739a13415ee630169a8ce764f86cf9f"},
+    {file = "msgpack-1.2.1-cp311-cp311-win32.whl", hash = "sha256:91054a783328e0ea7954b8771095705c8d2243b814743fbaadf14552c9c52c5d"},
+    {file = "msgpack-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8"},
+    {file = "msgpack-1.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ee967f7c7e1df2890c671ff2ee51a28ded0efc95da3e507176dee881ce36c66"},
+    {file = "msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35"},
+    {file = "msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c"},
+    {file = "msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0"},
+    {file = "msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a"},
+    {file = "msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6"},
+    {file = "msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a"},
+    {file = "msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1"},
+    {file = "msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64"},
+    {file = "msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac"},
+    {file = "msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24"},
+    {file = "msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07"},
+    {file = "msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064"},
+    {file = "msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056"},
+    {file = "msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc"},
+    {file = "msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d"},
+    {file = "msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155"},
+    {file = "msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402"},
+    {file = "msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c"},
+    {file = "msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6"},
+    {file = "msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707"},
+    {file = "msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9"},
+    {file = "msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a"},
+    {file = "msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d"},
+    {file = "msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7"},
+    {file = "msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889"},
+    {file = "msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720"},
+    {file = "msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190"},
+    {file = "msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d"},
+    {file = "msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24"},
+    {file = "msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7"},
+    {file = "msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb"},
+    {file = "msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b"},
+    {file = "msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7"},
+    {file = "msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273"},
+    {file = "msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1"},
+    {file = "msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc"},
+    {file = "msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde"},
+    {file = "msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4"},
+    {file = "msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d"},
+    {file = "msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355"},
+    {file = "msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c"},
+    {file = "msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1"},
+    {file = "msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2"},
+    {file = "msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107"},
+    {file = "msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647"},
+]
 
 [[package]]
 name = "packaging"
@@ -818,11 +961,12 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
+markers = {main = "extra == \"tui\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -997,6 +1141,246 @@ files = [
 ]
 
 [[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+description = "rapid fuzzy string matching"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "rapidfuzz-3.14.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:071d96b957a33b9296b9284b6350a0fb6d030b154a04efd7c15e56b98b79a517"},
+    {file = "rapidfuzz-3.14.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:667f40fe9c81ad129b198d236881b00dd9e8314d9cc72d03c3e16bdfe5879051"},
+    {file = "rapidfuzz-3.14.5-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9fff308486bbd2c8c24f25e8e152c7594d3fe8db265a2d6a1ce24d58671127f"},
+    {file = "rapidfuzz-3.14.5-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dfa552338f51aec280f17b02d28bace1e162d1a84ccd80e3339a57f98aedb56b"},
+    {file = "rapidfuzz-3.14.5-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:068b3e965ca9d9ee4debe40001ae7c3938ba646308afd33cf0c66618147db65c"},
+    {file = "rapidfuzz-3.14.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:88b7d31ff1cc5e9bc0e4406e6b1fa00b6d37163d50bb58091e9b976ff1129faa"},
+    {file = "rapidfuzz-3.14.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:eacb434410b8d9ca99a8d42352ef085cf423e3c76c1f0b86be2fcba3bff2952c"},
+    {file = "rapidfuzz-3.14.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:649712823f3abcdc48427147a5384fac15623ba435d0013959b52e6462521397"},
+    {file = "rapidfuzz-3.14.5-cp310-cp310-win32.whl", hash = "sha256:13cb79c23ef5516e4c4e3830877be8b19aa75203636be1163d690d37803f6504"},
+    {file = "rapidfuzz-3.14.5-cp310-cp310-win_amd64.whl", hash = "sha256:f2073495a7f9b75e57e600747ac09510d67683fd64d3228e009740b7ef88f9fe"},
+    {file = "rapidfuzz-3.14.5-cp310-cp310-win_arm64.whl", hash = "sha256:8166efddea49fdbc61185559f47593239e4794fd7c9044dd5a789d1a90af852d"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e251126d48615e1f02b4a178f2cd0cd4f0332b8a019c01a2e10480f7552554b4"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ab449c9abd0d4e1f8145dce0798a4c822a1a1933d613c764a641bea88b8bdab"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb2829fedd672dd7107267189dabe2bbe07972801d636014417c6861eb89e358"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d50e5861872935fece391351cbb5ba21d1bced277cf5e1143d207a0a35f1925"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:7092a216728f80c960bd6b3807275d1ee318b168986bd5dc523349581d4890b8"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9669753caef7fdc6529f6adcc5883ed98d65976445d9322e7dbdb6b697feee13"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:823b1b9d9230809d8edcc18872770764bfe8ef4357995e16744047c8ccf0e489"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f0b2af76b7e7060c09e1a0dfa9410eb19369cbe6164509bff2ef94094b54d2b6"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-win32.whl", hash = "sha256:c5801a89604c65ab4cc9e91b23bc4076d0ca80efd8c976fb63843d7879a85d7f"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-win_amd64.whl", hash = "sha256:d7ca16637c0ede8243f84074044bd0b2335a0341421f8227c85756de2d18c819"},
+    {file = "rapidfuzz-3.14.5-cp311-cp311-win_arm64.whl", hash = "sha256:8c90cdf8516d9057e502aa6003cea71cf5ec27cc44699ca52412b502a04761bb"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9"},
+    {file = "rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6737b35d5af7479c5bf9710f7b17edd9d2c43128d974d25fb4ea653e42c64609"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:95d937e74c1a7a1287dfb03b62a827be08ede10a155cf1af73bbf47f2b73ee6e"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:46b92a9970dcc34f0096901c792644094cab49554ac3547f35e3aebbdf0a3610"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e012177c8e8a8a0754ae0d6027d63042aa5ff036d9f40f07cb3466a6082e21b8"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ae6f53f99c9a0eca7a0afc5b4e45fc73bc1dd4ac74c00509031d76df80ed98"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-win32.whl", hash = "sha256:4a60f0057231188e3bd30216f7b4e0f279b11fa4ec818bb6c1d9f014d1562fbc"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:11bfc2ed8fbe4ab86bd516fadefab126f90e6dcadffa761739fcb304707dfd35"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313-win_arm64.whl", hash = "sha256:b486b5218808f6f4dc471b114b1054e63553db69705c97da0271f47bd706aedd"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39ef8658aaf67d51667e7bdaf7096f432333377d8302ac43c70b5df8a4cf89b8"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ad37a0be705b544af6296da8edddc260d10a8ae5462530fc9991f66498bb1f9"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d45e06f60729e07d9b20c205f7e5cff90b6ef2584e852eecf46e045aea69627d"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52da10236aa6212de71b9e170bace65b64b129c0dea7fc243d6c9ce976f5074"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:440d30faaf682ca496170a7f0cc5453ec942e3e079f0fd802c9a7f938dfb50a3"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:56227a61fd3d17b0cd9793132431f3a3d07c8654be96794ba9f89fe0fc8b2d09"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2e83cd2e25bb4edd97b689d9979d9c3acccdaaf26ceac08212ceece202febcfa"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:af3b859726cd3374287e405e14b9634563c078c5531a4f62375508addebddad1"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-win32.whl", hash = "sha256:8ce1d850b3c0178440efde9e884d98421b5e87ff925f364d6d79e23910d7593f"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-win_amd64.whl", hash = "sha256:c84af70bcf34e99aee894e46a0f1ac77f17d0ef828179c387407642e2466d28a"},
+    {file = "rapidfuzz-3.14.5-cp313-cp313t-win_arm64.whl", hash = "sha256:aac0ad28c686a5e72b81668b906c030ee28050b244544b8af68e12fb32543895"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1a31cc6d7d03e7318a0974c038959c59e19c752b81115f2e9138b3331cd64d45"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0298d357e2bc59d572da4db0bc631009b6f8f6c9bc8c11e99a12b833f16b6575"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59b3dba758661a318995655435c6ab20a04ade79fa51e75bc8dc107cac8df280"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4900143d82071bdda533b00300c40b14b963ff826b3642cc463b6dd0f036585e"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:feedf219672eef83ea6be6f3bb093bba396a8560fc75be85ba225f082903df0a"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:419e4397a36e2665ec992d8d64c20ba4b2a42500c76ecadeca78a4f19cb9cc32"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:97131ab2be39043054ee28d99e09efe316e6d53449b7e962dfcf3c2de8b2b246"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:593c00dac4e30231c35bf3b4f1da8ec0998762e9e94425586a5d636fcd57f9d0"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-win32.whl", hash = "sha256:0084b687b02b4e569b46d8d6d4ad25659528e6081cd6d067ca453a69035f07e4"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-win_amd64.whl", hash = "sha256:5dfa89d78f22cd773054caff44827b846161a29f2dcf7e78b8f90d086621e502"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314-win_arm64.whl", hash = "sha256:67f3f9d2b444268ab53e47d31bab89954888d23c04c6789f2c727e51fe4b1d13"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:77eac0526899b3c3ad1454bb2b03cdb491d67358ec8ef0c9c48bd61b632b431d"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b9c6bd754d11f6e78ac54e3d86b4b11dc1ba2f13e5fc958899574532897f5a99"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:738c96944d076deeaff70e92b65696ab4f7ecb8081d7791c5403a3257dfaf8ff"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4c1bca487a17fe4226b4ffb2d30e799d2b274d692cffa76bd0746f56235fca3"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:af6a90a4ed2a48fa1a2d17e9d824e6c7c950bea5bad0b707c77fd55751e6bfef"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bf5018938208d4597b2e679a4f8cff9fd252f1df53583130ae56281a21801b64"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c0919d1f89ddf91129906705723118ea09754171e4116f5a5dbc667c7bc9b261"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:93d8da883a35116d6813432177f35e570db5b0a5e30ecb0cbd7cb39c815735df"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-win32.whl", hash = "sha256:0f23e37019ec07712d58976b1ab2b889f8649a7f7c2f626a2f34ea9139e79279"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7d5ca9c7832e6879a707296d1463685f7c243a27846227044504741640caec66"},
+    {file = "rapidfuzz-3.14.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3e91dcd2549b8f8d843f98ba03a17e01f3d8b72ce942adbbb6761bc58ffce813"},
+    {file = "rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:578e6051f6d5e6200c259b47a103cf06bb875ab5814d17333fc0b5c290b22f4c"},
+    {file = "rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fbf1b8bb2695415b347f3727da1addca2acb82c9b97ac86bebf8b1bead1eb12d"},
+    {file = "rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f4a8f5cc84c7ad6bffa0e9947b33eb343ad66e6b53e94fe54378a5508c5ed53"},
+    {file = "rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c6d85283629646fa87acc22c66b30ea9d4de7f6fdf887daa2e30fa041829b5"},
+    {file = "rapidfuzz-3.14.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:dfef96543ced67d9513a422755db422ae1dc34dade0a1485e0b43e7342ed3ebf"},
+    {file = "rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e"},
+]
+
+[package.extras]
+all = ["numpy"]
+
+[[package]]
+name = "regex"
+version = "2026.7.19"
+description = "Alternative regular expression module, to replace re."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "regex-2026.7.19-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:555497390743af1a65045fa4527782d10ff5b88970359412baa4a1e628fe393b"},
+    {file = "regex-2026.7.19-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:343a4504e3fb688c47cad451221ca5d4814f42b1e16c0065bde9cbf7f473bd52"},
+    {file = "regex-2026.7.19-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5ebee1ee89c39c953baac6924fcde08c5bb427c4057510862f9d7c7bdb3d8665"},
+    {file = "regex-2026.7.19-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:062f8cb7a9739c4835d22bd96f370c59aba89f257adcfa53be3cc209e08d3ae0"},
+    {file = "regex-2026.7.19-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1123ef4211d763ee771d47916a1596e2f4915794f7aabdc1adcb20e4249a6951"},
+    {file = "regex-2026.7.19-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6e44c0e7c5664be20aee92085153150c0a7967310a73a43c0f832b7cd35d0dd3"},
+    {file = "regex-2026.7.19-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98c6ac18480fcdb33f35439183f1d2e79760ab41930309c6d951cb1f8e46694c"},
+    {file = "regex-2026.7.19-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4458124d71339f505bf1fb94f69fd1bb8fa9d2481eebfef27c10ef4f2b9e12f6"},
+    {file = "regex-2026.7.19-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbf300e2070bb35038660b3be1be4b91b0024edb41517e6996320b49b92b4175"},
+    {file = "regex-2026.7.19-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b2b506b1788df5fecd270a10d5e70a95fe77b87ea2b370a318043f6f5f817ee6"},
+    {file = "regex-2026.7.19-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:52579c60a6078be70a0e49c81d6e56d677f34cd439af281a0083b8c7bc75c095"},
+    {file = "regex-2026.7.19-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:2955907b7157a6660f27079edf7e0229e9c9c5325c77a2ef6a890cba91efa6f0"},
+    {file = "regex-2026.7.19-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:89dfee3319f5ae3f75ebd5c2445a809bb320252ba5529ffdafea4ef25d79cf1a"},
+    {file = "regex-2026.7.19-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d3143f159261b1ce5b24c261c590e5913370c3200c5e9ebbb92b5aa5e111902"},
+    {file = "regex-2026.7.19-cp310-cp310-win32.whl", hash = "sha256:64729333167c2dcaaa56a331d40ee097bd9c5617ffd51dabb09eaddafb1b532e"},
+    {file = "regex-2026.7.19-cp310-cp310-win_amd64.whl", hash = "sha256:1c398716054621aa300b3d411f467dda903806c5da0df6945ab73982b8d115db"},
+    {file = "regex-2026.7.19-cp310-cp310-win_arm64.whl", hash = "sha256:064f1760a5a4ade65c5419be23e782f29147528e8a66e0c42dd4cedb8d4e9fc6"},
+    {file = "regex-2026.7.19-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ac777001cdfc28b72477d93c8564bb7583081ea8fb45cdca3d568e0a4f87183c"},
+    {file = "regex-2026.7.19-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:59787bd5f8c70aa339084e961d2996b53fbdeab4d5393bba5c1fe1fc32e02bae"},
+    {file = "regex-2026.7.19-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:90c633e7e8d6bf4e992b8b36ce69e018f834b641dd6de8cea6d78c06ffa119c5"},
+    {file = "regex-2026.7.19-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87ccab0db8d5f4fbb0272642113c1adb2ffc698c16d3a0944580222331fa7a20"},
+    {file = "regex-2026.7.19-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9e50d748a32da622f256e8d505867f5d3c43a837c6a9f0efb149655fadd1042a"},
+    {file = "regex-2026.7.19-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf1516fe58fc104f39b2d1dbe2d5e27d0cd45c4be2e42ba6ee0cc763701ec3c7"},
+    {file = "regex-2026.7.19-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09f3e5287f94f17b709dc9a9e70865855feee835c861613be144218ce4ca82cc"},
+    {file = "regex-2026.7.19-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6383cd2ed53a646c659ba1fe65727db76437fdaa069e697a0b44a51d5843d864"},
+    {file = "regex-2026.7.19-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:09d3007fc76249a83cdd33de160d50e6cb77f54e09d8fa9e7148e10607ce24af"},
+    {file = "regex-2026.7.19-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:6f8c6e7a1cfa3dc9d0ee2de0e65e834537fa29992cc3976ffec914afc35c5dd5"},
+    {file = "regex-2026.7.19-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:b2ea4a3e8357be8849e833beeae757ac3c7a6b3fc055c03c808a53c91ad30d82"},
+    {file = "regex-2026.7.19-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:80115dd39481fd3a4b4080220799dbcacb921a844de4b827264ececacbe17c78"},
+    {file = "regex-2026.7.19-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d6ce43a0269d68cee79a7d1ade7def53c20f8f2a047b92d7b5d5bcc73ae88327"},
+    {file = "regex-2026.7.19-cp311-cp311-win32.whl", hash = "sha256:9be2a6647740dd3cca6acb24e87f03d7632cd280dbce9bbe40c26353a215a45d"},
+    {file = "regex-2026.7.19-cp311-cp311-win_amd64.whl", hash = "sha256:8d3469c91dd92ee41b7c95280edbd975ef1ba9195086686623a1c6e8935ce965"},
+    {file = "regex-2026.7.19-cp311-cp311-win_arm64.whl", hash = "sha256:36aacfb15faaff3ced55afbf35ec72f50d4aee22082c4f7fe0573a33e2fca92e"},
+    {file = "regex-2026.7.19-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2cc3460cedf7579948486eab03bc9ad7089df4d7281c0f47f4afe03e8d13f02d"},
+    {file = "regex-2026.7.19-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0e9554c8785eac5cffe6300f69a91f58ba72bc88a5f8d661235ad7c6aa5b8ccd"},
+    {file = "regex-2026.7.19-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7da47a0f248977f08e2cb659ff3c17ddc13a4d39b3a7baa0a81bf5b415430f6"},
+    {file = "regex-2026.7.19-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93db40c8de0815baab96a06e08a984bac71f989d13bab789e382158c5d426797"},
+    {file = "regex-2026.7.19-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:66bd62c59a5427746e8c44becae1d9b99d22fb13f30f492083dfb9ad7c45cc18"},
+    {file = "regex-2026.7.19-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1649eb39fcc9ea80c4d2f110fde2b8ab2aef3877b98f02ab9b14e961f418c511"},
+    {file = "regex-2026.7.19-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9dce8ec9695f531a1b8a6f314fd4b393adcccf2ea861db480cdf97a301d01a68"},
+    {file = "regex-2026.7.19-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3080a7fd38ef049bd489e01c970c97dd84ff446a885b0f1f6b26d9b1ad13ce11"},
+    {file = "regex-2026.7.19-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1d793a7988e04fcb1e2e135567443d82173225d657419ec09414a9b5a145b986"},
+    {file = "regex-2026.7.19-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e8b0abe7d870f53ca5143895fef7d1041a0c831a140d3dc2c760dd7ba25d4a8b"},
+    {file = "regex-2026.7.19-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:4e5413bd5f13d3a4e3539ca98f70f75e7fca92518dd7f117f030ebedd10b60cb"},
+    {file = "regex-2026.7.19-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:73b133a9e6fb512858e7f065e96f1180aa46646bc74a83aea62f1d314f3dd035"},
+    {file = "regex-2026.7.19-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dbe6493fbd27321b1d1f2dd4f5c7e5bd4d8b1d7cab7f32fd67db3d0b2ed8248a"},
+    {file = "regex-2026.7.19-cp312-cp312-win32.whl", hash = "sha256:ddd67571c10869f65a5d7dde536d1e066e306cc90de57d7de4d5f34802428bb5"},
+    {file = "regex-2026.7.19-cp312-cp312-win_amd64.whl", hash = "sha256:e30d40268a28d54ce0437031750497004c22602b8e3ab891f759b795a003b312"},
+    {file = "regex-2026.7.19-cp312-cp312-win_arm64.whl", hash = "sha256:de9208bb427130c82a5dbfd104f92c8876fc9559278c880b3002755bbbe9c83d"},
+    {file = "regex-2026.7.19-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f035d9dc1d25eff9d361456572231c7d27b5ccd473ca7dc0adfce732bd006d40"},
+    {file = "regex-2026.7.19-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c42572142ed0b9d5d261ba727157c426510da78e20828b66bbb855098b8a4e38"},
+    {file = "regex-2026.7.19-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:40b34dd88658e4fedd2fddbf0275ac970d00614b731357f425722a3ed1983d11"},
+    {file = "regex-2026.7.19-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c41c63992bf1874cebb6e7f56fd7d3c007924659a604ae3d90e427d40d4fd13"},
+    {file = "regex-2026.7.19-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d3372064506b94dd2c67c845f2db8062e9e9ba84d04e33cb96d7d33c11fe1ae"},
+    {file = "regex-2026.7.19-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fce7760bf283405b2c7999cab3da4e72f7deca6396013115e3f7a955db9760da"},
+    {file = "regex-2026.7.19-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0d702548d89d572b2929879bc883bb7a4c4709efafe4512cadee56c55c9bd15"},
+    {file = "regex-2026.7.19-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d446c6ac40bb6e05025ccee55b84d80fe9bf8e93010ffc4bb9484f13d498835f"},
+    {file = "regex-2026.7.19-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4c3501bfa814ab07b5580741f9bf78dfdfe146a04057f82df9e2402d2a975939"},
+    {file = "regex-2026.7.19-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c4585c3e64b4f9e583b4d2683f18f5d5d872b3d71dcf24594b74ecc23602fa96"},
+    {file = "regex-2026.7.19-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:571fde9741eb0ccde23dd4e0c1d50fbae910e901fa7e629faf39b2dda740d220"},
+    {file = "regex-2026.7.19-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:15b364b9b98d6d2fe1a85034c23a3180ff913f46caddc3895f6fd65186255ccc"},
+    {file = "regex-2026.7.19-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffd8893ccc1c2fce6e0d6ca402d716fe1b29db70c7132609a05955e31b2aa8f2"},
+    {file = "regex-2026.7.19-cp313-cp313-win32.whl", hash = "sha256:f0fa4fa9c3632d708742baf2282f2055c11d888a790362670a403cbf48a2c404"},
+    {file = "regex-2026.7.19-cp313-cp313-win_amd64.whl", hash = "sha256:d51ffd3427640fa2da6ade574ceba932f210ad095f65fcc450a2b0a0d454868e"},
+    {file = "regex-2026.7.19-cp313-cp313-win_arm64.whl", hash = "sha256:c670fe7be5b6020b76bc6e8d2196074657e1327595bca93a389e1a76ab130ad8"},
+    {file = "regex-2026.7.19-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db47b561c9afd884baa1f96f797c9ca369872c4b65912bc691cfa99e68340af2"},
+    {file = "regex-2026.7.19-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:65dcd28d3eba2ab7c2fd906485cc301392b47cc2234790d27d4e4814e02cdfda"},
+    {file = "regex-2026.7.19-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f2e7f8e2ab6c2922be02c7ec45185aa5bd771e2e57b95455ee343a44d8130dff"},
+    {file = "regex-2026.7.19-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe31f28c94402043161876a258a9c6f757cb485905c7614ce8d6cd40e6b7bdc1"},
+    {file = "regex-2026.7.19-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8f6fa298bb4f7f58a33334406218ba74716e68feddf5e4e54cd5d8082705abf"},
+    {file = "regex-2026.7.19-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cc1b2440423a851fad781309dd87843868f4f66a6bcd1ddb9225cf4ec2c84732"},
+    {file = "regex-2026.7.19-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ac59a0900474a52b7c04af8196affc22bd9842acb0950df12f7b813e983609a"},
+    {file = "regex-2026.7.19-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4896db1f4ce0576765b8272aa922df324e0f5b9bb2c3d03044ff32a7234a9aba"},
+    {file = "regex-2026.7.19-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4e6883a021db30511d9fb8cfb0f222ce1f2c369f7d4d8b0448f449a93ba0bdfc"},
+    {file = "regex-2026.7.19-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:09523a592938aa9f587fb74467c63ff0cf88fc3df14c82ab0f0517dcf76aaa62"},
+    {file = "regex-2026.7.19-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:1ebac3474b8589fce2f9b225b650afd61448f7c73a5d0255a10cc6366471aed1"},
+    {file = "regex-2026.7.19-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:4a0530bb1b8c1c985e7e2122e2b4d3aedd8a3c21c6bfddae6767c4405668b56e"},
+    {file = "regex-2026.7.19-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2ef7eeb108c47ce7bcc9513e51bcb1bf57e8f483d52fce68a8642e3527141ae0"},
+    {file = "regex-2026.7.19-cp313-cp313t-win32.whl", hash = "sha256:64b6ca7391a1395c2638dd5c7456d67bea44fc6c5e8e92c5dc8aa6a8f23292b4"},
+    {file = "regex-2026.7.19-cp313-cp313t-win_amd64.whl", hash = "sha256:f04b9f56b0e0614c0126be12c2c2d9f8850c1e57af302bd0a63bed379d4af974"},
+    {file = "regex-2026.7.19-cp313-cp313t-win_arm64.whl", hash = "sha256:fcee38cd8e5089d6d4f048ba1233b3ad76e5954f545382180889112ff5cb712d"},
+    {file = "regex-2026.7.19-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a81758ed242b861b72e778ba34d41366441a2e10b16b472784c88da2dea7e2dd"},
+    {file = "regex-2026.7.19-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4aa5435cdb3eb6f55fe98a171b05e3fbcd95fadaa4aa32acf62afd9b0cfdbcac"},
+    {file = "regex-2026.7.19-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:60be8693a1dadc210bbcbc0db3e26da5f7d01d1d5a3da594e99b4fa42df404f5"},
+    {file = "regex-2026.7.19-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d19662dbedbe783d323196312d38f5ba53cf56296378252171985da6899887d3"},
+    {file = "regex-2026.7.19-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d15df07081d91b76ff20d43f94592ee110330152d617b730fdbe5ef9fb680053"},
+    {file = "regex-2026.7.19-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:56ad4d9f77df871a99e25c37091052a02528ec0eb059de928ee33956b854b45b"},
+    {file = "regex-2026.7.19-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7322ec6cc9fba9d49ab888bb82d67ac5625627aa168f0165139b17018df3fb8a"},
+    {file = "regex-2026.7.19-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9c7472192ebfad53a6be7c4a8bfb2d64b81c0e93a1fc8c57e1dd0b638297b5d1"},
+    {file = "regex-2026.7.19-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c10b82c2634df08dfb13b1f04e38fe310d086ee092f4f69c0c8da234251e556e"},
+    {file = "regex-2026.7.19-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:17ed5692f6acc4183e98331101a5f9e4f64d72fe58b753da4d444a2c77d05b12"},
+    {file = "regex-2026.7.19-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:22a992de9a0d91bda927bf02b94351d737a0302905432c88a53de7c4b9ce62e2"},
+    {file = "regex-2026.7.19-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:618a0aed532be87294c4477b0481f3aa0f1520f4014a4374dd4cf789b4cd2c97"},
+    {file = "regex-2026.7.19-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ce9e679f776649746729b6c86382da519ef649c8e34cc41df0d2e5e0f6c36d4"},
+    {file = "regex-2026.7.19-cp314-cp314-win32.whl", hash = "sha256:73f272fba87b8ccfe70a137d02a54af386f6d27aa509fbffdd978f5947aae1aa"},
+    {file = "regex-2026.7.19-cp314-cp314-win_amd64.whl", hash = "sha256:d721e53758b2cca74990185eb0671dd466d7a388a1a45d0c6f4c13cef41a68ac"},
+    {file = "regex-2026.7.19-cp314-cp314-win_arm64.whl", hash = "sha256:65fa6cb38ed5e9c3637e68e544f598b39c3b86b808ed0627a67b68320384b459"},
+    {file = "regex-2026.7.19-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:5a2721c8720e2cb3c209925dfb9200199b4b07361c9e01d321719404b21458b3"},
+    {file = "regex-2026.7.19-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:199535629f25caf89698039af3d1ad5fcae7f933e2112c73f1cdf49165c99518"},
+    {file = "regex-2026.7.19-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9b60d7814174f059e5de4ab98271cc5ba9259cfea55273a81544dceea32dc8d9"},
+    {file = "regex-2026.7.19-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbece16025afda5e3031af0c4059207e61dcf73ef13af844964f57f387d1c435"},
+    {file = "regex-2026.7.19-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d24ecb4f5e009ea0bd275ee37ad9953b32005e2e5e60f8bbae16da0dbbf0d3a0"},
+    {file = "regex-2026.7.19-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8cae6fd77a5b72dae505084b1a2ee0360139faf72fedbab667cd7cc65aae7a6a"},
+    {file = "regex-2026.7.19-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9724e6cb5e478cd7d8cabf027826178739cb18cf0e117d0e32814d479fa02276"},
+    {file = "regex-2026.7.19-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:572fc57b0009c735ee56c175ea021b637a15551a312f56734277f923d6fd0f6c"},
+    {file = "regex-2026.7.19-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:20568e182eb82d39a6bf7cff3fd58566f14c75c6f74b2c8c96537eecf9010e3a"},
+    {file = "regex-2026.7.19-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:1d58561843f0ff7dc78b4c28b5e2dc388f3eff94ebc8a232a3adba961fc00009"},
+    {file = "regex-2026.7.19-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:61bb1bd45520aacd56dd80943bd34991fb5350afdd1f36f2282230fd5154a218"},
+    {file = "regex-2026.7.19-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:cd3584591ea4429026cdb931b054342c2bcf189b44ff367f8d5c15bc092a2966"},
+    {file = "regex-2026.7.19-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cc26a66e212fa5d6c6170c3a40d99d888db3020c6fdab1523250d4341382e44"},
+    {file = "regex-2026.7.19-cp314-cp314t-win32.whl", hash = "sha256:2c4e61e2e1be56f63ec3cc618aa9e0de81ef6f43d177205451840022e24f5b78"},
+    {file = "regex-2026.7.19-cp314-cp314t-win_amd64.whl", hash = "sha256:c639ea314df70a7b2811e8020448c75af8c9445f5a60f8a4ced81c306a9380c2"},
+    {file = "regex-2026.7.19-cp314-cp314t-win_arm64.whl", hash = "sha256:9a15e785f244f3e07847b984ce8773fc3da10a9f3c131cc49a4c5b4d672b4547"},
+    {file = "regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5"},
+]
+
+[[package]]
+name = "rich"
+version = "14.3.4"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = true
+python-versions = ">=3.8.0"
+groups = ["main"]
+markers = "extra == \"tui\""
+files = [
+    {file = "rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952"},
+    {file = "rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "ruff"
 version = "0.15.16"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -1049,6 +1433,21 @@ files = [
 ]
 
 [[package]]
+name = "symspellpy"
+version = "6.10.0"
+description = "Python SymSpell"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "symspellpy-6.10.0-py3-none-any.whl", hash = "sha256:e31707f6d6e06b89973588c02c0c7941c9ca1e3144859a8e2e46d8b815dda75e"},
+    {file = "symspellpy-6.10.0.tar.gz", hash = "sha256:7434e15c92b2af6ec0141df98f249b35a7ddc5496a410c2649c1ac74d84a3dfb"},
+]
+
+[package.extras]
+editdistpy = ["editdistpy (>=0.1.3)"]
+
+[[package]]
 name = "tqdm"
 version = "4.68.1"
 description = "Fast, Extensible Progress Meter"
@@ -1093,6 +1492,30 @@ files = [
     {file = "wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8"},
     {file = "wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9"},
 ]
+
+[[package]]
+name = "wordfreq"
+version = "3.1.1"
+description = "Look up the frequencies of words in many languages, based on many sources of data."
+optional = false
+python-versions = ">=3.8,<4"
+groups = ["main"]
+files = [
+    {file = "wordfreq-3.1.1-py3-none-any.whl", hash = "sha256:4b1c6ecffc6198be3396d5cf871c4423ca71c907c231348d352dd54d62b97473"},
+    {file = "wordfreq-3.1.1.tar.gz", hash = "sha256:7943098975f25c2a70e1151ee5a62083b14a5f86f6cc5703cc9526f716ceb408"},
+]
+
+[package.dependencies]
+ftfy = ">=6.1"
+langcodes = ">=3.0"
+locate = ">=1.1.1,<2.0.0"
+msgpack = ">=1.0.7,<2.0.0"
+regex = ">=2023.10.3"
+
+[package.extras]
+cjk = ["ipadic (>=1.0.0,<2.0.0)", "jieba (>=0.42)", "mecab-ko-dic (>=1.0.0,<2.0.0)", "mecab-python3 (>=1.0.5,<2.0.0)"]
+jieba = ["jieba (>=0.42)"]
+mecab = ["ipadic (>=1.0.0,<2.0.0)", "mecab-ko-dic (>=1.0.0,<2.0.0)", "mecab-python3 (>=1.0.5,<2.0.0)"]
 
 [[package]]
 name = "zstandard"
@@ -1207,7 +1630,10 @@ cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\
 [package.extras]
 cffi = ["cffi (>=1.11)"]
 
+[extras]
+tui = ["rich"]
+
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.12"
-content-hash = "1cf15d225f38230e6de38afd69af5d9de20bb6901401094fe57e1d9d56e1008b"
+python-versions = ">=3.12,<4.0"
+content-hash = "1c8e893d838637e3660ab3dd66d34fd2ea0235cce822a22b4ea13704c7d16c8d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "charitarthchugh",email = "37895518+charitarthchugh@users.noreply.github.com"}
 ]
 license = "MIT"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "httpx (>=0.28.1,<0.29.0)",
     "pillow (>=12.2.0,<13.0.0)",
@@ -18,8 +18,15 @@ dependencies = [
     "pyyaml (>=6.0.0,<7.0.0)",
     "lingua-language-detector (>=2.0.0,<3.0.0)",
     "img2pdf (>=0.5.0,<0.7.0)",
-    "markdownify (>=1.2.0,<2.0.0)"
+    "markdownify (>=1.2.0,<2.0.0)",
+    "wordfreq (>=3.0.0,<4.0.0)",
+    "rapidfuzz (>=3.0.0,<4.0.0)",
+    "symspellpy (>=6.7.0,<7.0.0)"
 ]
+
+[project.optional-dependencies]
+# Only needed for the live progress dashboard (`--tui`).
+tui = ["rich (>=13.0.0,<15.0.0)"]
 
 [tool.poetry]
 packages = [{ include = "paperscale", from = "src" }]

--- a/src/paperscale/cli.py
+++ b/src/paperscale/cli.py
@@ -171,6 +171,7 @@ def _handle_evaluate(args: argparse.Namespace) -> int:
                         pplx_url=args.pplx_url,
                         pplx_model=args.pplx_model,
                         extra_words=extra_words,
+                        sym=sym,  # reuse the dictionary built for the correction metric
                         progress=lambda doc, label=label: (ph.advance(), rep.log(f"pplx {label}: {doc}")),
                     )
                     db.write_pplx(label, [row for rows in by_doc.values() for row in rows])

--- a/src/paperscale/cli.py
+++ b/src/paperscale/cli.py
@@ -1,0 +1,187 @@
+"""`paperscale evaluate` — reference-free OCR-model comparison.
+
+Reached via a shim in `pipeline.cli_main`: when the first CLI token is
+``evaluate`` the pipeline delegates to `main` here. Heavy scoring deps
+(wordfreq, rapidfuzz) are imported inside the handler so importing this module
+stays cheap.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+from typing import Sequence
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="paperscale")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    ev = subparsers.add_parser(
+        "evaluate",
+        help="rank OCR models against each other from existing run outputs (no ground truth)",
+        description="Corpus-level, reference-free leaderboard over one or more model runs.",
+    )
+    ev.add_argument(
+        "--run",
+        action="append",
+        required=True,
+        metavar="LABEL=PATH",
+        help="a model run: LABEL=PATH where PATH is a workspace dir, a dir of .jsonl, or a .jsonl file. Repeatable.",
+    )
+    ev.add_argument("--db", type=Path, default=Path("./evaluation.sqlite"), help="SQLite output path (default ./evaluation.sqlite)")
+    ev.add_argument("--dictionary", action="append", type=Path, default=[], help="extra word-list file (one word per line/whitespace). Repeatable.")
+    ev.add_argument("--pplx", action="store_true", help="also score perplexity via an external vLLM (raw + dictionary-corrected)")
+    ev.add_argument("--pplx-url", default="http://localhost:8000", help="base URL of the vLLM OpenAI-compatible server")
+    ev.add_argument("--pplx-model", default=None, help="model id served by --pplx-url (required with --pplx)")
+    ev.add_argument("--tui", action="store_true", help="show a live progress dashboard (needs the 'tui' extra)")
+    ev.set_defaults(handler=_handle_evaluate)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.handler(args)
+
+
+def _parse_runs(entries: list[str]) -> list[tuple[str, str]]:
+    runs: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for entry in entries:
+        if "=" not in entry:
+            raise SystemExit(f"--run must be LABEL=PATH, got {entry!r}")
+        label, path = entry.split("=", 1)
+        label = label.strip()
+        if not label or not path:
+            raise SystemExit(f"--run must be LABEL=PATH, got {entry!r}")
+        if label in seen:
+            raise SystemExit(f"duplicate --run label {label!r}")
+        seen.add(label)
+        runs.append((label, path))
+    return runs
+
+
+def _load_dictionary(paths: list[Path]) -> frozenset[str]:
+    words: set[str] = set()
+    for p in paths:
+        for token in p.read_text(encoding="utf-8").split():
+            words.add(token.lower())
+    return frozenset(words)
+
+
+def _handle_evaluate(args: argparse.Namespace) -> int:
+    from paperscale.evaluation.db import EvalDB
+    from paperscale.evaluation.metrics import bow_f1, garbage_token_fraction, one_minus_ned
+    from paperscale.evaluation.runs import load_run
+    from paperscale.evaluation.spell import build_dictionary, correction_counts
+    from paperscale.evaluation.textlayer import compute_textlayer_agreement
+
+    if args.pplx and not args.pplx_model:
+        raise SystemExit("--pplx requires --pplx-model (the model id served by --pplx-url)")
+
+    runs = _parse_runs(args.run)
+    extra_words = _load_dictionary(args.dictionary)
+
+    all_pages = []
+    all_metas = []
+    pages_by_model: dict[str, list] = {}
+    for label, path in runs:
+        pages, metas = load_run(label, path)
+        pages_by_model[label] = pages
+        all_pages.extend(pages)
+        all_metas.extend(metas)
+
+    from paperscale.tui import make_reporter
+
+    db = EvalDB(args.db)
+    leaderboard = ""
+    try:
+        with make_reporter(args.tui, title="paperscale evaluate") as rep:
+            rep.set_stat("models", len(pages_by_model))
+            rep.set_stat("documents", len({m.doc for m in all_metas}))
+            rep.set_stat("pages", len(all_pages))
+
+            ph = rep.phase("register runs", total=len(runs))
+            for label, path in runs:
+                db.register_run(label, path, args.pplx_model if args.pplx else None)
+                ph.advance()
+            ph.done()
+
+            # Corrections — how much a spell checker must change the text (correctable)
+            # and how much it cannot fix (uncorrectable). Shares pplx's dictionary.
+            sym = build_dictionary(extra_words)
+            ph = rep.phase("corrections", total=len(all_pages))
+            correction_rows = []
+            for p in all_pages:
+                ph.advance()
+                counts = correction_counts(p.text, sym)
+                if counts is None:
+                    continue
+                n, corrected, uncorrectable = counts
+                correction_rows.append((p.model, p.doc, p.page, corrected / n, uncorrectable / n))
+            db.write_correction_rate(correction_rows)
+            ph.done()
+
+            # Garbage-token fraction + peer agreement.
+            ph = rep.phase("token & peer metrics", total=2)
+            garbage_rows = [(p.model, p.doc, p.page, s) for p in all_pages if (s := garbage_token_fraction(p.text)) is not None]
+            db.write_garbage_fraction(garbage_rows)
+            ph.advance()
+            page_texts: dict[tuple[str, int], dict[str, str]] = defaultdict(dict)
+            for p in all_pages:
+                page_texts[(p.doc, p.page)][p.model] = p.text
+            peer_rows = []
+            for (doc, page), mt in page_texts.items():
+                models_here = sorted(mt)
+                if len(models_here) < 2:
+                    continue
+                for m in models_here:
+                    for peer in models_here:
+                        if m != peer:
+                            peer_rows.append((m, peer, doc, page, bow_f1(mt[m], mt[peer]), one_minus_ned(mt[m], mt[peer])))
+            if len(pages_by_model) < 2:
+                rep.log("only one model run — peer agreement skipped (needs >=2 runs).")
+            db.write_peer_agreement(peer_rows)
+            ph.advance()
+            ph.done()
+
+            # Metric 4 — text-layer agreement (calibration subset).
+            ph = rep.phase("text-layer", total=len(all_pages))
+            textlayer_rows, skip = compute_textlayer_agreement(all_pages, all_metas, progress=lambda note: ph.advance())
+            ph.done()
+            db.write_textlayer_agreement(textlayer_rows)
+            rep.log(
+                f"text-layer: {len(textlayer_rows)} rows; skipped {skip.docs_with_fallback} fallback-docs, "
+                f"{skip.docs_missing_pdf} missing-PDF docs, {skip.pages_blank_layer} blank-layer pages."
+            )
+
+            # Metric 5 — quality-reject rate (doc-level).
+            db.write_reject_rate([(m.model, m.doc, m.fallback_pages, m.total_pages) for m in all_metas])
+
+            # Optional — perplexity.
+            if args.pplx:
+                from paperscale.evaluation.pplx import score_run_pplx
+
+                total_docs = sum(len({p.doc for p in pages}) for pages in pages_by_model.values())
+                ph = rep.phase("perplexity", total=total_docs)
+                for label, pages in pages_by_model.items():
+                    by_doc = score_run_pplx(
+                        pages,
+                        pplx_url=args.pplx_url,
+                        pplx_model=args.pplx_model,
+                        extra_words=extra_words,
+                        progress=lambda doc, label=label: (ph.advance(), rep.log(f"pplx {label}: {doc}")),
+                    )
+                    db.write_pplx(label, [row for rows in by_doc.values() for row in rows])
+                ph.done()
+
+        leaderboard = db.leaderboard()
+    finally:
+        db.close()
+    print(leaderboard)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/paperscale/evaluation/db.py
+++ b/src/paperscale/evaluation/db.py
@@ -1,0 +1,273 @@
+"""SQLite persistence + leaderboard for reference-free OCR evaluation.
+
+One table per metric; one ``pplx_<model>`` table per model (perplexity columns
+vary per scorer and are queried per-model). Every ``write_*`` is idempotent:
+it deletes the rows it is about to (re)write for the affected model(s) first,
+so re-running an evaluation replaces rather than duplicates.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+# Static per-metric schema. pplx tables are created on demand (see _pplx_table).
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS runs (
+    model TEXT PRIMARY KEY,
+    input_path TEXT,
+    pplx_scorer_model TEXT
+);
+CREATE TABLE IF NOT EXISTS correction_rate (
+    model TEXT, doc TEXT, page INTEGER, correction_rate REAL, uncorrectable_rate REAL
+);
+CREATE TABLE IF NOT EXISTS garbage_fraction (
+    model TEXT, doc TEXT, page INTEGER, score REAL
+);
+CREATE TABLE IF NOT EXISTS peer_agreement (
+    model TEXT, peer TEXT, doc TEXT, page INTEGER, bow_f1 REAL, one_minus_ned REAL
+);
+CREATE TABLE IF NOT EXISTS textlayer_agreement (
+    model TEXT, doc TEXT, page INTEGER, bow_f1 REAL, one_minus_ned REAL
+);
+CREATE TABLE IF NOT EXISTS reject_rate (
+    model TEXT, doc TEXT, fallback_pages INTEGER, total_pages INTEGER
+);
+"""
+
+_PPLX_COLS = (
+    "n_tokens_raw",
+    "sum_logprob_raw",
+    "ppl_raw",
+    "n_tokens_corrected",
+    "sum_logprob_corrected",
+    "ppl_corrected",
+)
+
+
+def _pplx_table(model: str) -> str:
+    return "pplx_" + re.sub(r"\W+", "_", model)
+
+
+def _distinct_models(rows: list, idx: int = 0) -> set:
+    return {r[idx] for r in rows}
+
+
+class EvalDB:
+    def __init__(self, path: str | Path) -> None:
+        self.conn = sqlite3.connect(str(path))
+        self.conn.executescript(_SCHEMA)
+        self.conn.commit()
+
+    # --- writers ---------------------------------------------------------
+
+    def register_run(
+        self, model: str, input_path: str, pplx_scorer_model: str | None = None
+    ) -> None:
+        self.conn.execute(
+            "INSERT OR REPLACE INTO runs (model, input_path, pplx_scorer_model) VALUES (?, ?, ?)",
+            (model, input_path, pplx_scorer_model),
+        )
+        self.conn.commit()
+
+    def _replace(self, table: str, rows: Iterable, cols: tuple[str, ...]) -> None:
+        rows = list(rows)
+        for model in _distinct_models(rows):
+            self.conn.execute(f"DELETE FROM {table} WHERE model = ?", (model,))
+        placeholders = ", ".join("?" * len(cols))
+        self.conn.executemany(
+            f"INSERT INTO {table} ({', '.join(cols)}) VALUES ({placeholders})", rows
+        )
+        self.conn.commit()
+
+    def write_correction_rate(self, rows) -> None:
+        self._replace(
+            "correction_rate", rows, ("model", "doc", "page", "correction_rate", "uncorrectable_rate")
+        )
+
+    def write_garbage_fraction(self, rows) -> None:
+        self._replace("garbage_fraction", rows, ("model", "doc", "page", "score"))
+
+    def write_peer_agreement(self, rows) -> None:
+        self._replace(
+            "peer_agreement",
+            rows,
+            ("model", "peer", "doc", "page", "bow_f1", "one_minus_ned"),
+        )
+
+    def write_textlayer_agreement(self, rows) -> None:
+        self._replace(
+            "textlayer_agreement",
+            rows,
+            ("model", "doc", "page", "bow_f1", "one_minus_ned"),
+        )
+
+    def write_reject_rate(self, rows) -> None:
+        self._replace(
+            "reject_rate", rows, ("model", "doc", "fallback_pages", "total_pages")
+        )
+
+    def write_pplx(self, model: str, rows) -> None:
+        table = _pplx_table(model)
+        cols = ("doc", "page") + _PPLX_COLS
+        coldefs = "doc TEXT, page INTEGER, " + ", ".join(f"{c} REAL" for c in _PPLX_COLS)
+        # n_tokens columns are integers, but REAL stores them faithfully via sqlite affinity.
+        self.conn.execute(f"DROP TABLE IF EXISTS {table}")
+        self.conn.execute(f"CREATE TABLE {table} ({coldefs})")
+        placeholders = ", ".join("?" * len(cols))
+        self.conn.executemany(
+            f"INSERT INTO {table} ({', '.join(cols)}) VALUES ({placeholders})",
+            list(rows),
+        )
+        self.conn.commit()
+
+    # --- leaderboard -----------------------------------------------------
+
+    def _pplx_tables(self) -> list[str]:
+        cur = self.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'pplx_%'"
+        )
+        return [r[0] for r in cur.fetchall()]
+
+    def _models(self) -> list[str]:
+        """All models seen across any table (union), sorted for determinism."""
+        models: set = set()
+        for table in ("runs", "correction_rate", "garbage_fraction", "peer_agreement",
+                      "textlayer_agreement", "reject_rate"):
+            cur = self.conn.execute(f"SELECT DISTINCT model FROM {table}")
+            models.update(r[0] for r in cur.fetchall())
+        return sorted(models)
+
+    def _per_doc_means(self, table: str, value_expr: str) -> dict[str, dict[str, float]]:
+        """{model: {doc: mean(value_expr) over that model+doc's rows}}."""
+        cur = self.conn.execute(
+            f"SELECT model, doc, AVG({value_expr}) FROM {table} GROUP BY model, doc"
+        )
+        out: dict[str, dict[str, float]] = {}
+        for model, doc, mean in cur.fetchall():
+            out.setdefault(model, {})[doc] = mean
+        return out
+
+    def _overall_mean(self, table: str, value_expr: str) -> dict[str, float]:
+        cur = self.conn.execute(
+            f"SELECT model, AVG({value_expr}) FROM {table} GROUP BY model"
+        )
+        return {model: mean for model, mean in cur.fetchall()}
+
+    @staticmethod
+    def _win_rate(per_doc: dict[str, dict[str, float]], higher_better: bool) -> dict[str, str]:
+        """Fraction of common docs where a model is best. 'n/a' if <2 models / no common docs."""
+        models = list(per_doc)
+        if len(models) < 2:
+            return {m: "n/a" for m in models}
+        common = set.intersection(*(set(per_doc[m]) for m in models)) if models else set()
+        if not common:
+            return {m: "n/a" for m in models}
+        wins = {m: 0 for m in models}
+        for doc in common:
+            vals = {m: per_doc[m][doc] for m in models}
+            best = max(vals.values()) if higher_better else min(vals.values())
+            for m, v in vals.items():
+                if v == best:
+                    wins[m] += 1
+        n = len(common)
+        return {m: f"{wins[m] / n:.2f}" for m in models}
+
+    def leaderboard(self) -> str:
+        models = self._models()
+        if not models:
+            return "(no models)"
+
+        # Each spec: (col-label, {model: mean-str}, {model: win-rate-str})
+        columns: list[tuple[str, dict[str, str], dict[str, str] | None]] = []
+
+        def add_scalar(label: str, table: str, expr: str, higher_better: bool) -> None:
+            overall = self._overall_mean(table, expr)
+            per_doc = self._per_doc_means(table, expr)
+            means = {m: (f"{overall[m]:.3f}" if m in overall else "-") for m in models}
+            wr = self._win_rate(per_doc, higher_better)
+            wins = {m: wr.get(m, "n/a") for m in models}
+            columns.append((label, means, wins))
+
+        # correction_rate: how much the spell checker changed the text (lower better,
+        # win-rate on it); uncorrectable_rate: garbage it couldn't fix (mean only).
+        add_scalar("corr_rate", "correction_rate", "correction_rate", higher_better=False)
+        uncorr = self._overall_mean("correction_rate", "uncorrectable_rate")
+        columns.append(("uncorr_rate", {m: (f"{uncorr[m]:.3f}" if m in uncorr else "-") for m in models}, None))
+        add_scalar("garbage", "garbage_fraction", "score", higher_better=False)
+
+        # peer_agreement: two value columns, win-rate on bow_f1.
+        for label, expr in (("peer_f1", "bow_f1"), ("peer_ned", "one_minus_ned")):
+            overall = self._overall_mean("peer_agreement", expr)
+            means = {m: (f"{overall[m]:.3f}" if m in overall else "-") for m in models}
+            if label == "peer_f1":
+                wr = self._win_rate(self._per_doc_means("peer_agreement", expr), True)
+                columns.append((label, means, {m: wr.get(m, "n/a") for m in models}))
+            else:
+                columns.append((label, means, None))
+
+        for label, expr in (("tl_f1", "bow_f1"), ("tl_ned", "one_minus_ned")):
+            overall = self._overall_mean("textlayer_agreement", expr)
+            means = {m: (f"{overall[m]:.3f}" if m in overall else "-") for m in models}
+            if label == "tl_f1":
+                wr = self._win_rate(self._per_doc_means("textlayer_agreement", expr), True)
+                columns.append((label, means, {m: wr.get(m, "n/a") for m in models}))
+            else:
+                columns.append((label, means, None))
+
+        # reject_rate: per-doc value is already fallback/total (one row per doc);
+        # lower is better.
+        add_scalar("reject_rate", "reject_rate",
+                   "CAST(fallback_pages AS REAL) / total_pages", higher_better=False)
+
+        # pplx: mean ppl_raw / ppl_corrected across each model's own table.
+        pplx_tables = self._pplx_tables()
+        if pplx_tables:
+            raw: dict[str, str] = {}
+            corr: dict[str, str] = {}
+            for m in models:
+                t = _pplx_table(m)
+                if t in pplx_tables:
+                    row = self.conn.execute(
+                        f"SELECT AVG(ppl_raw), AVG(ppl_corrected) FROM {t}"
+                    ).fetchone()
+                    raw[m] = f"{row[0]:.3f}" if row[0] is not None else "-"
+                    corr[m] = f"{row[1]:.3f}" if row[1] is not None else "-"
+                else:
+                    raw[m] = corr[m] = "-"
+            columns.append(("ppl_raw", raw, None))
+            columns.append(("ppl_corr", corr, None))
+
+        return self._render(models, columns)
+
+    @staticmethod
+    def _render(models, columns) -> str:
+        # Build header + rows. Each metric column becomes "mean" and, when it has
+        # a win-rate, a "<label>_win" column.
+        headers = ["model"]
+        cells_per_model: dict[str, list[str]] = {m: [m] for m in models}
+        for label, means, wins in columns:
+            headers.append(label)
+            for m in models:
+                cells_per_model[m].append(means[m])
+            if wins is not None:
+                headers.append(label + "_win")
+                for m in models:
+                    cells_per_model[m].append(wins[m])
+
+        rows = [cells_per_model[m] for m in models]
+        widths = [
+            max(len(headers[i]), *(len(r[i]) for r in rows)) if rows else len(headers[i])
+            for i in range(len(headers))
+        ]
+        def fmt(cells):
+            return "  ".join(c.ljust(widths[i]) for i, c in enumerate(cells))
+
+        lines = [fmt(headers), fmt(["-" * w for w in widths])]
+        lines += [fmt(r) for r in rows]
+        return "\n".join(lines)
+
+    def close(self) -> None:
+        self.conn.close()

--- a/src/paperscale/evaluation/db.py
+++ b/src/paperscale/evaluation/db.py
@@ -150,11 +150,11 @@ class EvalDB:
             out.setdefault(model, {})[doc] = mean
         return out
 
-    def _overall_mean(self, table: str, value_expr: str) -> dict[str, float]:
-        cur = self.conn.execute(
-            f"SELECT model, AVG({value_expr}) FROM {table} GROUP BY model"
-        )
-        return {model: mean for model, mean in cur.fetchall()}
+    @staticmethod
+    def _doc_mean(per_doc: dict[str, dict[str, float]]) -> dict[str, float]:
+        """Mean over a model's per-doc means -- each doc weighted equally, matching
+        the win-rate weighting (a 100-page doc must not dominate a 1-page doc)."""
+        return {m: sum(d.values()) / len(d) for m, d in per_doc.items() if d}
 
     @staticmethod
     def _win_rate(per_doc: dict[str, dict[str, float]], higher_better: bool) -> dict[str, str]:
@@ -184,8 +184,8 @@ class EvalDB:
         columns: list[tuple[str, dict[str, str], dict[str, str] | None]] = []
 
         def add_scalar(label: str, table: str, expr: str, higher_better: bool) -> None:
-            overall = self._overall_mean(table, expr)
             per_doc = self._per_doc_means(table, expr)
+            overall = self._doc_mean(per_doc)
             means = {m: (f"{overall[m]:.3f}" if m in overall else "-") for m in models}
             wr = self._win_rate(per_doc, higher_better)
             wins = {m: wr.get(m, "n/a") for m in models}
@@ -194,25 +194,27 @@ class EvalDB:
         # correction_rate: how much the spell checker changed the text (lower better,
         # win-rate on it); uncorrectable_rate: garbage it couldn't fix (mean only).
         add_scalar("corr_rate", "correction_rate", "correction_rate", higher_better=False)
-        uncorr = self._overall_mean("correction_rate", "uncorrectable_rate")
+        uncorr = self._doc_mean(self._per_doc_means("correction_rate", "uncorrectable_rate"))
         columns.append(("uncorr_rate", {m: (f"{uncorr[m]:.3f}" if m in uncorr else "-") for m in models}, None))
         add_scalar("garbage", "garbage_fraction", "score", higher_better=False)
 
         # peer_agreement: two value columns, win-rate on bow_f1.
         for label, expr in (("peer_f1", "bow_f1"), ("peer_ned", "one_minus_ned")):
-            overall = self._overall_mean("peer_agreement", expr)
+            per_doc = self._per_doc_means("peer_agreement", expr)
+            overall = self._doc_mean(per_doc)
             means = {m: (f"{overall[m]:.3f}" if m in overall else "-") for m in models}
             if label == "peer_f1":
-                wr = self._win_rate(self._per_doc_means("peer_agreement", expr), True)
+                wr = self._win_rate(per_doc, True)
                 columns.append((label, means, {m: wr.get(m, "n/a") for m in models}))
             else:
                 columns.append((label, means, None))
 
         for label, expr in (("tl_f1", "bow_f1"), ("tl_ned", "one_minus_ned")):
-            overall = self._overall_mean("textlayer_agreement", expr)
+            per_doc = self._per_doc_means("textlayer_agreement", expr)
+            overall = self._doc_mean(per_doc)
             means = {m: (f"{overall[m]:.3f}" if m in overall else "-") for m in models}
             if label == "tl_f1":
-                wr = self._win_rate(self._per_doc_means("textlayer_agreement", expr), True)
+                wr = self._win_rate(per_doc, True)
                 columns.append((label, means, {m: wr.get(m, "n/a") for m in models}))
             else:
                 columns.append((label, means, None))

--- a/src/paperscale/evaluation/metrics.py
+++ b/src/paperscale/evaluation/metrics.py
@@ -1,0 +1,84 @@
+"""Pure per-page text-quality metrics. No I/O, no run/db knowledge.
+
+All functions operate on a single string (or a pair of strings). Functions that
+can be undefined for a page (no scorable tokens) return ``None`` so the caller
+drops the row rather than averaging in a misleading 0.0.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+from rapidfuzz.distance import Levenshtein
+
+_WORD = re.compile(r"\w+", re.UNICODE)
+_VOWELS = set("aeiouyAEIOUY")
+_LINK = re.compile(r"\[([^\]]*)\]\([^)]*\)")  # [text](url) -> text
+_MD_CHARS = re.compile(r"[#*_>`~]")
+_WS = re.compile(r"\s+")
+
+
+def _is_garbage(tok: str) -> bool:
+    # >=4 identical consecutive chars (aaaa, ----)
+    if re.search(r"(.)\1{3,}", tok):
+        return True
+    core = tok.strip("[](){}.,;:!?\"'")
+    if len(core) > 40:  # absurdly long unbroken run
+        return True
+    letters = [c for c in core if c.isalpha()]
+    # alpha-digit soup: mixes letters and digits within one token
+    if letters and any(c.isdigit() for c in core):
+        return True
+    if len(letters) > 2 and letters == core.split("'")[0].replace("-", "") and all(c.isalpha() for c in core):
+        # all-consonant alphabetic word (no vowel)
+        if not any(c in _VOWELS for c in core):
+            return True
+    # mid-word case alternation: >=2 lower->upper transitions inside the token
+    transitions = sum(1 for a, b in zip(core, core[1:]) if a.islower() and b.isupper())
+    if transitions >= 2:
+        return True
+    return False
+
+
+def garbage_token_fraction(text: str) -> float | None:
+    """Fraction of whitespace tokens that look like OCR garbage. None if empty."""
+    tokens = text.split()
+    if not tokens:
+        return None
+    return sum(1 for t in tokens if _is_garbage(t)) / len(tokens)
+
+
+def normalize_markdown(text: str) -> str:
+    """OmniDocBench-style structural normalization (no lowercasing).
+
+    Strip link syntax to its anchor text, drop markdown emphasis/heading/quote/code
+    markers, and collapse all whitespace. Used before edit-distance comparison so
+    formatting differences don't dominate.
+    """
+    text = _LINK.sub(r"\1", text)
+    text = _MD_CHARS.sub("", text)
+    return _WS.sub(" ", text).strip()
+
+
+def bow_f1(a: str, b: str) -> float:
+    """Multiset bag-of-words F1 between two texts (order-insensitive)."""
+    ca, cb = Counter(_WORD.findall(a.lower())), Counter(_WORD.findall(b.lower()))
+    if not ca and not cb:
+        return 1.0
+    if not ca or not cb:
+        return 0.0
+    overlap = sum((ca & cb).values())
+    if overlap == 0:
+        return 0.0
+    precision = overlap / sum(ca.values())
+    recall = overlap / sum(cb.values())
+    return 2 * precision * recall / (precision + recall)
+
+
+def one_minus_ned(a: str, b: str) -> float:
+    """1 - normalized edit distance on normalized markdown (order-sensitive)."""
+    na, nb = normalize_markdown(a), normalize_markdown(b)
+    if not na and not nb:
+        return 1.0
+    return Levenshtein.normalized_similarity(na, nb)

--- a/src/paperscale/evaluation/metrics.py
+++ b/src/paperscale/evaluation/metrics.py
@@ -30,10 +30,10 @@ def _is_garbage(tok: str) -> bool:
     # alpha-digit soup: mixes letters and digits within one token
     if letters and any(c.isdigit() for c in core):
         return True
-    if len(letters) > 2 and letters == core.split("'")[0].replace("-", "") and all(c.isalpha() for c in core):
-        # all-consonant alphabetic word (no vowel)
-        if not any(c in _VOWELS for c in core):
-            return True
+    # vowel-less alphabetic run (OCR garble like "brwn"/"jmps"); skip ALL-CAPS so
+    # real acronyms (PDF, XML, CSV) aren't flagged. _VOWELS includes 'y'.
+    if len(letters) > 2 and not core.isupper() and not any(c in _VOWELS for c in letters):
+        return True
     # mid-word case alternation: >=2 lower->upper transitions inside the token
     transitions = sum(1 for a, b in zip(core, core[1:]) if a.islower() and b.isupper())
     if transitions >= 2:

--- a/src/paperscale/evaluation/pplx.py
+++ b/src/paperscale/evaluation/pplx.py
@@ -28,6 +28,7 @@ would lump its span into the leading offset.)
 from __future__ import annotations
 
 import math
+import warnings
 
 import httpx
 
@@ -116,6 +117,16 @@ def _score_pass(
         plps = _prompt_logprobs(client, url, model, prompt)
         toks = [_pick(e) for e in plps if e is not None]
         decoded_len = sum(len(dec) for _, dec in toks)
+        if decoded_len > len(prompt):
+            # Tokens should tile the prompt exactly (null-token span = len(prompt) - decoded_len >= 0).
+            # A tokenizer whose decoded_token strings carry marker glyphs (SentencePiece "_", BPE "G")
+            # can overrun, making the leading offset negative -> page attribution shifts. Surface it
+            # instead of silently clamping; validate against the real --pplx-model before trusting numbers.
+            warnings.warn(
+                f"pplx: decoded tokens ({decoded_len} chars) overrun the prompt ({len(prompt)} chars); "
+                "per-page perplexity attribution may be miscalibrated for this model's tokenizer.",
+                stacklevel=2,
+            )
         cursor = max(0, len(prompt) - decoded_len)  # span of the skipped null token
         for logprob, dec in toks:
             page = _assign_page(boundaries, cursor)
@@ -133,6 +144,7 @@ def score_run_pplx(
     extra_words: frozenset[str] = frozenset(),
     client: "httpx.Client | None" = None,
     progress=None,
+    sym=None,
 ) -> dict[str, list[tuple]]:
     """Score every page raw and dictionary-corrected; return DB row tuples per doc.
 
@@ -144,7 +156,7 @@ def score_run_pplx(
     own_client = client is None
     if own_client:
         client = httpx.Client(timeout=httpx.Timeout(600.0))
-    sym = None
+    # sym may be supplied by the caller (the correction metric already built one); else built lazily.
     try:
         by_doc: dict[str, list[PageText]] = {}
         for p in pages:

--- a/src/paperscale/evaluation/pplx.py
+++ b/src/paperscale/evaluation/pplx.py
@@ -1,0 +1,177 @@
+"""Opt-in reference-free perplexity scorer for OCR page text.
+
+Scores each page's text -- both raw and dictionary-corrected -- through an
+external vLLM ``/v1/completions`` endpoint using ``prompt_logprobs``. The
+raw-minus-corrected perplexity gap isolates surface-typo noise (spelling
+slips a dictionary can fix) from residual incoherence the model still can't
+predict after correction.
+
+vLLM response shape (``choices[0].prompt_logprobs``): a list with one entry per
+prompt token, in order. The FIRST entry is ``null`` -- there is no logprob for
+the first token and, crucially, no ``decoded_token`` for it either. Each
+non-null entry is a dict mapping ``token-id-string -> {"logprob": float,
+"decoded_token": str, "rank": int, ...}``. With ``prompt_logprobs: 0`` the actual
+prompt token is the ``rank == 0`` entry (usually the only one).
+
+Char-offset -> page mapping: we walk a running char cursor over the non-null
+tokens' ``decoded_token`` strings and assign each token to the page whose
+``[start, next_start)`` span contains the token's START offset. The first
+(null) token has no ``decoded_token``, so we infer its char span as
+``len(prompt) - sum(len(decoded) for non-null tokens)`` -- tokens tile the whole
+prompt, so the leftover prefix length is exactly the first token's span. That
+keeps every subsequent offset aligned without needing the null token's text.
+The null token is excluded from logprob sums but still accounts for its span.
+(Assumes only index 0 is null, per the vLLM contract; any other null entry
+would lump its span into the leading offset.)
+"""
+
+from __future__ import annotations
+
+import math
+
+import httpx
+
+from paperscale.evaluation.runs import PageText
+from paperscale.evaluation.spell import build_dictionary, correct_text
+
+__all__ = ["build_dictionary", "correct_text", "score_run_pplx"]
+
+_CHARS_PER_TOKEN = 3
+_MAX_TOKENS_PER_CHUNK = 32_000
+
+
+def _ppl(n_tokens: int, sum_logprob: float) -> float:
+    """Perplexity ``exp(-mean_logprob)``. NaN when no tokens scored."""
+    if n_tokens == 0:
+        return float("nan")
+    return math.exp(-sum_logprob / n_tokens)
+
+
+def _pick(entry: dict) -> tuple[float, str]:
+    """From one prompt_logprobs entry, take the rank-0 token (or the sole one)."""
+    chosen = None
+    for v in entry.values():
+        if v.get("rank") == 0:
+            chosen = v
+            break
+    if chosen is None:
+        chosen = next(iter(entry.values()))
+    return chosen["logprob"], chosen["decoded_token"]
+
+
+def _assign_page(boundaries: list[tuple[int, int]], offset: int) -> int:
+    """Page number whose ``[start, next_start)`` span contains ``offset``."""
+    pn = boundaries[0][0]
+    for page, start in boundaries:
+        if start <= offset:
+            pn = page
+        else:
+            break
+    return pn
+
+
+def _chunk_pages(items: list[tuple[int, str]]) -> list[list[tuple[int, str]]]:
+    """Split pages into sequential chunks (at page boundaries) under the token cap.
+
+    The first page of each chunk after the first loses cross-page conditioning.
+    """
+    chunks: list[list[tuple[int, str]]] = []
+    cur: list[tuple[int, str]] = []
+    cur_chars = 0
+    for page, text in items:
+        add = len(text) + 1  # + inter-page "\n"
+        if cur and (cur_chars + add) // _CHARS_PER_TOKEN > _MAX_TOKENS_PER_CHUNK:
+            chunks.append(cur)
+            cur, cur_chars = [], 0
+        cur.append((page, text))
+        cur_chars += add
+    if cur:
+        chunks.append(cur)
+    return chunks
+
+
+def _prompt_logprobs(client: httpx.Client, url: str, model: str, prompt: str) -> list:
+    resp = client.post(
+        f"{url}/v1/completions",
+        json={"model": model, "prompt": prompt, "max_tokens": 1, "prompt_logprobs": 0},
+    )
+    resp.raise_for_status()
+    return resp.json()["choices"][0]["prompt_logprobs"]
+
+
+def _score_pass(
+    items: list[tuple[int, str]], client: httpx.Client, url: str, model: str
+) -> dict[int, tuple[int, float]]:
+    """Score one pass (raw or corrected) -> {page: (n_tokens, sum_logprob)}."""
+    acc: dict[int, list] = {page: [0, 0.0] for page, _ in items}
+    for chunk in _chunk_pages(items):
+        # Join chunk pages with "\n", tracking each page's start offset.
+        boundaries: list[tuple[int, int]] = []
+        off = 0
+        for page, text in chunk:
+            boundaries.append((page, off))
+            off += len(text) + 1
+        prompt = "\n".join(text for _, text in chunk)
+
+        plps = _prompt_logprobs(client, url, model, prompt)
+        toks = [_pick(e) for e in plps if e is not None]
+        decoded_len = sum(len(dec) for _, dec in toks)
+        cursor = max(0, len(prompt) - decoded_len)  # span of the skipped null token
+        for logprob, dec in toks:
+            page = _assign_page(boundaries, cursor)
+            acc[page][0] += 1
+            acc[page][1] += logprob
+            cursor += len(dec)
+    return {page: (n, s) for page, (n, s) in acc.items()}
+
+
+def score_run_pplx(
+    pages: list[PageText],
+    *,
+    pplx_url: str,
+    pplx_model: str,
+    extra_words: frozenset[str] = frozenset(),
+    client: "httpx.Client | None" = None,
+    progress=None,
+) -> dict[str, list[tuple]]:
+    """Score every page raw and dictionary-corrected; return DB row tuples per doc.
+
+    Row order (positional -- the DB layer relies on it)::
+
+        (doc, page, n_tokens_raw, sum_logprob_raw, ppl_raw,
+         n_tokens_corrected, sum_logprob_corrected, ppl_corrected)
+    """
+    own_client = client is None
+    if own_client:
+        client = httpx.Client(timeout=httpx.Timeout(600.0))
+    sym = None
+    try:
+        by_doc: dict[str, list[PageText]] = {}
+        for p in pages:
+            by_doc.setdefault(p.doc, []).append(p)
+
+        result: dict[str, list[tuple]] = {}
+        for doc, plist in by_doc.items():
+            plist = sorted(plist, key=lambda p: p.page)
+            raw = _score_pass([(p.page, p.text) for p in plist], client, pplx_url, pplx_model)
+
+            if sym is None:
+                sym = build_dictionary(extra_words)
+            corr = _score_pass(
+                [(p.page, correct_text(p.text, sym)) for p in plist], client, pplx_url, pplx_model
+            )
+
+            rows = []
+            for p in plist:
+                n_r, s_r = raw[p.page]
+                n_c, s_c = corr[p.page]
+                rows.append(
+                    (doc, p.page, n_r, s_r, _ppl(n_r, s_r), n_c, s_c, _ppl(n_c, s_c))
+                )
+            result[doc] = rows
+            if progress is not None:
+                progress(doc)
+        return result
+    finally:
+        if own_client:
+            client.close()

--- a/src/paperscale/evaluation/runs.py
+++ b/src/paperscale/evaluation/runs.py
@@ -1,0 +1,108 @@
+"""Load OCR run outputs (Dolma JSONL) into per-page rows for evaluation.
+
+A run's results are Dolma JSONL documents (one record per PDF) written by
+`pipeline.build_dolma_document`. Each record carries:
+
+- ``text``      full document text (all pages concatenated)
+- ``metadata``  ``{"Source-File", "pdf-total-pages", "total-fallback-pages", ...}``
+- ``attributes.pdf_page_numbers``  ``[[start_char, end_char, page_num], ...]`` spans
+
+The model name is NOT recorded in the JSONL, so the caller supplies an explicit
+``label`` (see ``paperscale evaluate --run label=path``). Documents join across
+models by ``metadata["Source-File"]`` -- never by the record ``id`` (it is a
+sha1 of the text and therefore differs per model).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+
+@dataclass(frozen=True)
+class PageText:
+    """One page of one model's output. ``doc`` is the source PDF path (join key)."""
+
+    model: str
+    doc: str
+    page: int
+    text: str
+
+
+@dataclass(frozen=True)
+class DocMeta:
+    """Per-document metadata for a single model's run of one PDF."""
+
+    model: str
+    doc: str
+    total_pages: int
+    fallback_pages: int
+    source_file: str
+
+
+class DuplicateSourceFileError(RuntimeError):
+    """Two records in one run share a Source-File -- the join key is ambiguous."""
+
+
+def _iter_jsonl_paths(path: Path) -> list[Path]:
+    """Resolve an input into concrete .jsonl files.
+
+    Accepts a workspace dir (globs ``results/*.jsonl``), a bare dir of ``*.jsonl``,
+    or a single ``.jsonl`` file.
+    """
+    if path.is_file():
+        return [path]
+    if not path.is_dir():
+        raise FileNotFoundError(f"run path does not exist: {path}")
+    results = sorted((path / "results").glob("*.jsonl"))
+    if results:
+        return results
+    return sorted(path.glob("*.jsonl"))
+
+
+def _iter_records(paths: list[Path]) -> Iterator[dict]:
+    for p in paths:
+        with p.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    yield json.loads(line)
+
+
+def load_run(label: str, path: str | Path) -> tuple[list[PageText], list[DocMeta]]:
+    """Load one model's run into ``(pages, metas)``.
+
+    Pages with a zero-length span (blank/blank-accepted pages -> empty text) are
+    skipped entirely. Raises ``DuplicateSourceFileError`` if a Source-File appears
+    in more than one record (ambiguous cross-model join key).
+    """
+    paths = _iter_jsonl_paths(Path(path))
+    pages: list[PageText] = []
+    metas: list[DocMeta] = []
+    seen: set[str] = set()
+
+    for rec in _iter_records(paths):
+        source_file = rec["metadata"]["Source-File"]
+        if source_file in seen:
+            raise DuplicateSourceFileError(f"{label}: duplicate Source-File {source_file!r} in run")
+        seen.add(source_file)
+
+        text = rec["text"]
+        for start, end, page_num in rec["attributes"]["pdf_page_numbers"]:
+            if end <= start:
+                continue  # blank / blank-accepted page -> no row
+            pages.append(PageText(model=label, doc=source_file, page=page_num, text=text[start:end]))
+
+        metas.append(
+            DocMeta(
+                model=label,
+                doc=source_file,
+                total_pages=rec["metadata"].get("pdf-total-pages", len(rec["attributes"]["pdf_page_numbers"])),
+                fallback_pages=rec["metadata"].get("total-fallback-pages", 0),
+                source_file=source_file,
+            )
+        )
+
+    return pages, metas

--- a/src/paperscale/evaluation/spell.py
+++ b/src/paperscale/evaluation/spell.py
@@ -1,0 +1,74 @@
+"""Shared symspell dictionary + correction utilities.
+
+Used by the required ``correction_rate`` metric (how much a spell checker has to
+change the text) and by the opt-in ``pplx`` corrected-perplexity pass, so both
+run over the *same* dictionary. symspell is a core dependency.
+"""
+
+from __future__ import annotations
+
+import re
+
+from symspellpy import SymSpell, Verbosity
+
+_TOKEN_RE = re.compile(r"[A-Za-z]+")
+_MAX_EDIT_DISTANCE = 2
+
+
+def build_dictionary(extra_words: frozenset[str] = frozenset()) -> SymSpell:
+    """Build a SymSpell dictionary from the 50k most common English words.
+
+    Frequencies come from ``wordfreq``; ``extra_words`` are added with a low
+    count so they pass lookups without shadowing real corrections.
+    """
+    from wordfreq import top_n_list, word_frequency
+
+    sym = SymSpell(max_dictionary_edit_distance=_MAX_EDIT_DISTANCE)
+    for word in top_n_list("en", 50_000):
+        count = max(1, int(word_frequency(word, "en") * 1_000_000_000))
+        sym.create_dictionary_entry(word, count)
+    for word in extra_words:
+        sym.create_dictionary_entry(word, 1)
+    return sym
+
+
+def correct_text(text: str, sym: SymSpell) -> str:
+    """Spell-correct only alphabetic tokens that fail the dictionary lookup.
+
+    Numbers, punctuation, whitespace, and already-known words are left exactly
+    as-is, preserving char offsets between tokens so page boundaries stay
+    meaningful.
+    """
+
+    def repl(m: "re.Match[str]") -> str:
+        tok = m.group(0)
+        if tok.lower() in sym.words:  # known -> untouched (case preserved)
+            return tok
+        sugg = sym.lookup(tok, Verbosity.CLOSEST, max_edit_distance=_MAX_EDIT_DISTANCE)
+        return sugg[0].term if sugg else tok
+
+    return _TOKEN_RE.sub(repl, text)
+
+
+def correction_counts(text: str, sym: SymSpell) -> tuple[int, int, int] | None:
+    """Return ``(n_tokens, n_corrected, n_uncorrectable)`` over alphabetic tokens.
+
+    Mirrors ``correct_text``'s decisions exactly:
+    - a token in the dictionary is left alone (neither corrected nor uncorrectable);
+    - a non-dictionary token with an edit-distance<=2 suggestion is *corrected*;
+    - a non-dictionary token with no suggestion is *uncorrectable*.
+
+    Returns ``None`` when the page has no alphabetic tokens (row skipped, not 0.0).
+    """
+    tokens = _TOKEN_RE.findall(text)
+    if not tokens:
+        return None
+    corrected = uncorrectable = 0
+    for tok in tokens:
+        if tok.lower() in sym.words:
+            continue
+        if sym.lookup(tok, Verbosity.CLOSEST, max_edit_distance=_MAX_EDIT_DISTANCE):
+            corrected += 1
+        else:
+            uncorrectable += 1
+    return len(tokens), corrected, uncorrectable

--- a/src/paperscale/evaluation/textlayer.py
+++ b/src/paperscale/evaluation/textlayer.py
@@ -48,6 +48,10 @@ def compute_textlayer_agreement(
 
     skip_docs: set[tuple[str, str]] = set()
     for (model, doc), fb in fallback.items():
+        # Skip the WHOLE doc if any page fell back: fallback pages fill natural_text with
+        # pdftotext output, so comparing them to the text layer is circular (~1.0). This
+        # sacrifices the doc's good pages too -- acceptable since this metric is only a
+        # calibration subset, not full coverage.
         if fb > 0:
             report.docs_with_fallback += 1
             skip_docs.add((model, doc))

--- a/src/paperscale/evaluation/textlayer.py
+++ b/src/paperscale/evaluation/textlayer.py
@@ -1,0 +1,70 @@
+"""Reference-free text-layer agreement: how well each model's OCR of a page
+agrees with the PDF's embedded text layer (pdftotext).
+
+Only a calibration signal: docs with fallback pages (whose natural_text is
+already filled with pdftotext output) are skipped, as are docs whose PDF is
+missing and pages whose text layer is effectively blank (scanned images).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from paperscale.anchor import get_anchor_text
+from paperscale.evaluation.metrics import bow_f1, one_minus_ned
+from paperscale.evaluation.runs import DocMeta, PageText
+
+# Below this many alphanumeric chars the "text layer" is a scanned image, not real text.
+_MIN_ALNUM = 25
+
+
+@dataclass
+class SkipReport:
+    docs_missing_pdf: int
+    docs_with_fallback: int
+    pages_blank_layer: int
+
+
+def _pdf_exists(path: str) -> bool:
+    # Patchable seam for tests.
+    return os.path.exists(path)
+
+
+def _extract_layer(doc: str, page: int) -> str:
+    """pdftotext, falling back to pypdf if poppler is unavailable/errors."""
+    try:
+        return get_anchor_text(doc, page, "pdftotext")
+    except (FileNotFoundError, AssertionError, OSError):
+        return get_anchor_text(doc, page, "pypdf")
+
+
+def compute_textlayer_agreement(
+    pages: list[PageText], metas: list[DocMeta], progress=None
+) -> tuple[list[tuple[str, str, int, float, float]], SkipReport]:
+    """``progress``: optional callable(note) invoked once per page (instrumentation only)."""
+    fallback = {(m.model, m.doc): m.fallback_pages for m in metas}
+    report = SkipReport(docs_missing_pdf=0, docs_with_fallback=0, pages_blank_layer=0)
+
+    skip_docs: set[tuple[str, str]] = set()
+    for (model, doc), fb in fallback.items():
+        if fb > 0:
+            report.docs_with_fallback += 1
+            skip_docs.add((model, doc))
+        elif not _pdf_exists(doc):
+            report.docs_missing_pdf += 1
+            skip_docs.add((model, doc))
+
+    rows: list[tuple[str, str, int, float, float]] = []
+    for pg in pages:
+        if progress is not None:
+            progress(f"{pg.doc}#{pg.page}")
+        if (pg.model, pg.doc) in skip_docs:
+            continue
+        layer = _extract_layer(pg.doc, pg.page)
+        if sum(c.isalnum() for c in layer) < _MIN_ALNUM:
+            report.pages_blank_layer += 1
+            continue
+        rows.append((pg.model, pg.doc, pg.page, bow_f1(pg.text, layer), one_minus_ned(pg.text, layer)))
+
+    return rows, report

--- a/src/paperscale/pipeline.py
+++ b/src/paperscale/pipeline.py
@@ -1221,6 +1221,10 @@ def _log_final_metrics(args) -> None:
 
 def cli_main():
     """Synchronous entry point for the CLI."""
+    if sys.argv[1:2] == ["evaluate"]:
+        from paperscale.cli import main as evaluate_main
+
+        return evaluate_main(sys.argv[1:])
     return asyncio.run(main())
 
 

--- a/src/paperscale/pipeline.py
+++ b/src/paperscale/pipeline.py
@@ -1221,6 +1221,9 @@ def _log_final_metrics(args) -> None:
 
 def cli_main():
     """Synchronous entry point for the CLI."""
+    # Route `paperscale evaluate ...` to the subcommand CLI. The pipeline itself takes a
+    # positional workspace path (plus flags), never a subcommand, so this only misroutes if
+    # a workspace were literally named "evaluate" -- not worth guarding against.
     if sys.argv[1:2] == ["evaluate"]:
         from paperscale.cli import main as evaluate_main
 

--- a/src/paperscale/tui.py
+++ b/src/paperscale/tui.py
@@ -1,0 +1,184 @@
+"""Progress reporting abstraction, decoupled from any specific renderer.
+
+Two implementations back the same tiny interface:
+
+- ``NullReporter`` — the default. Emits phase headers and ``log`` lines to
+  stderr as plain text (matching pre-TUI behaviour) and does nothing fancy.
+- ``RichReporter`` — an immich-go-style live dashboard (header + stats table +
+  per-phase progress bars + a scrolling log tail), rendered with ``rich.Live``.
+
+Use ``make_reporter`` to pick one. Both are context managers and expose the
+same ``phase`` / ``log`` / ``set_stat`` surface, so callers (evaluate today, the
+OCR pipeline later) stay renderer-agnostic. Reporters are pure instrumentation:
+driving them must never change a caller's output.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Phase(Protocol):
+    """A unit of work with an optional known total (for a progress bar)."""
+
+    def advance(self, n: int = 1) -> None: ...
+    def done(self) -> None: ...
+
+
+class ProgressReporter(Protocol):
+    def __enter__(self) -> "ProgressReporter": ...
+    def __exit__(self, *exc) -> None: ...
+    def phase(self, name: str, total: int | None = None) -> Phase: ...
+    def log(self, message: str) -> None: ...
+    def set_stat(self, name: str, value) -> None: ...
+
+
+# --------------------------------------------------------------------------- #
+# Null implementation (default / non-TTY)
+# --------------------------------------------------------------------------- #
+class _NullPhase:
+    def advance(self, n: int = 1) -> None:
+        pass
+
+    def done(self) -> None:
+        pass
+
+
+class NullReporter:
+    """No live UI. Prints phase starts and log lines to stderr, like before."""
+
+    def __enter__(self) -> "NullReporter":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        pass
+
+    def phase(self, name: str, total: int | None = None) -> Phase:
+        print(f"[{name}]", file=sys.stderr)
+        return _NullPhase()
+
+    def log(self, message: str) -> None:
+        print(message, file=sys.stderr)
+
+    def set_stat(self, name: str, value) -> None:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# Rich implementation (immich-go style dashboard)
+# --------------------------------------------------------------------------- #
+class _RichPhase:
+    def __init__(self, reporter: "RichReporter", task_id: int, total: int | None) -> None:
+        self._reporter = reporter
+        self._task_id = task_id
+        self._total = total
+
+    def advance(self, n: int = 1) -> None:
+        self._reporter._progress.advance(self._task_id, n)
+        self._reporter._refresh()
+
+    def done(self) -> None:
+        if self._total is None:
+            # mark an indeterminate task complete so its bar fills
+            self._reporter._progress.update(self._task_id, total=1, completed=1)
+        else:
+            self._reporter._progress.update(self._task_id, completed=self._total)
+        self._reporter._refresh()
+
+
+class RichReporter:
+    """Live dashboard: header + stats table + phase bars + log tail."""
+
+    def __init__(self, title: str, *, console=None, max_log: int = 8) -> None:
+        from rich.console import Console
+        from rich.progress import BarColumn, MofNCompleteColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+
+        self._title = title
+        self._console = console or Console(stderr=True)
+        self._max_log = max_log
+        self._stats: dict[str, object] = {}
+        self._log: list[str] = []
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            console=self._console,
+        )
+        self._live = None
+
+    # -- context management -------------------------------------------------- #
+    def __enter__(self) -> "RichReporter":
+        from rich.live import Live
+
+        self._live = Live(self._render(), console=self._console, refresh_per_second=12, transient=False)
+        self._live.__enter__()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self._live is not None:
+            self._refresh()
+            self._live.__exit__(*exc)
+            self._live = None
+
+    # -- reporter surface ---------------------------------------------------- #
+    def phase(self, name: str, total: int | None = None) -> Phase:
+        task_id = self._progress.add_task(name, total=total)
+        self._refresh()
+        return _RichPhase(self, task_id, total)
+
+    def log(self, message: str) -> None:
+        self._log.append(message)
+        if len(self._log) > self._max_log:
+            self._log = self._log[-self._max_log :]
+        self._refresh()
+
+    def set_stat(self, name: str, value) -> None:
+        self._stats[name] = value
+        self._refresh()
+
+    # -- rendering ----------------------------------------------------------- #
+    def _refresh(self) -> None:
+        if self._live is not None:
+            self._live.update(self._render())
+
+    def _render(self):
+        from rich.panel import Panel
+        from rich.table import Table
+
+        stats = Table.grid(padding=(0, 2))
+        stats.add_column(style="cyan", justify="right")
+        stats.add_column(style="bold white")
+        for k, v in self._stats.items():
+            stats.add_row(str(k), str(v))
+
+        log_body = "\n".join(self._log) if self._log else "…"
+
+        outer = Table.grid(expand=True)
+        outer.add_row(Panel(stats, title=self._title, title_align="left"))
+        outer.add_row(self._progress)
+        outer.add_row(Panel(log_body, title="events", title_align="left", height=self._max_log + 2))
+        return outer
+
+
+# --------------------------------------------------------------------------- #
+# Factory
+# --------------------------------------------------------------------------- #
+def make_reporter(tui: bool, *, title: str, stream=None) -> ProgressReporter:
+    """Pick a reporter. RichReporter only when --tui is on AND output is a TTY.
+
+    Raises a clear error if --tui is requested but ``rich`` isn't installed.
+    """
+    stream = stream if stream is not None else sys.stderr
+    if not tui:
+        return NullReporter()
+    if not getattr(stream, "isatty", lambda: False)():
+        return NullReporter()  # piped/redirected — keep output clean
+    try:
+        import rich  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - env-dependent
+        raise SystemExit("--tui requires the 'tui' extra: poetry install --extras tui") from exc
+    return RichReporter(title)

--- a/tests/evaluation/fixtures.py
+++ b/tests/evaluation/fixtures.py
@@ -1,0 +1,50 @@
+"""Synthetic Dolma-JSONL fixtures mirroring pipeline.build_dolma_document output."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+
+def make_dolma_record(source_file: str, page_texts: list[str], *, fallback_pages: int = 0) -> dict:
+    """Build one Dolma document record from per-page texts.
+
+    An empty string for a page produces a zero-length span (blank page), exactly
+    as build_dolma_document does when natural_text is None.
+    """
+    document_text = ""
+    spans = []
+    for i, content in enumerate(page_texts):
+        piece = (content + ("\n" if i < len(page_texts) - 1 else "")) if content else ""
+        start = len(document_text)
+        document_text += piece
+        spans.append([start, len(document_text), i + 1])
+    return {
+        "id": hashlib.sha1(document_text.encode()).hexdigest(),
+        "text": document_text,
+        "source": "paperscale",
+        "metadata": {
+            "Source-File": source_file,
+            "pdf-total-pages": len(page_texts),
+            "total-fallback-pages": fallback_pages,
+        },
+        "attributes": {"pdf_page_numbers": spans},
+    }
+
+
+def write_run(tmpdir: Path, records: list[dict], *, as_workspace: bool = True) -> Path:
+    """Write records as a run. Returns the path to pass to load_run.
+
+    as_workspace=True writes results/output_0.jsonl (workspace layout); otherwise
+    writes a bare run.jsonl file and returns that file.
+    """
+    if as_workspace:
+        results = tmpdir / "results"
+        results.mkdir(parents=True, exist_ok=True)
+        path = results / "output_0.jsonl"
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+        return tmpdir
+    path = tmpdir / "run.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return path

--- a/tests/evaluation/test_cli.py
+++ b/tests/evaluation/test_cli.py
@@ -1,0 +1,58 @@
+"""End-to-end test of `paperscale evaluate` (non-pplx path)."""
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from paperscale.cli import _parse_runs, main
+from tests.evaluation.fixtures import make_dolma_record, write_run
+
+CLEAN = ["The quick brown fox jumps over the lazy dog.", "Every good boy deserves fruit today."]
+GARBLED = ["Teh qckuz brwn fxo jmps ovr teh lzy dg.", "Evry gd boy dsrvs frt3 tdy xkcdqz."]
+
+
+class ParseRunsTest(unittest.TestCase):
+    def test_rejects_missing_equals(self):
+        with self.assertRaises(SystemExit):
+            _parse_runs(["nopath"])
+
+    def test_rejects_duplicate_label(self):
+        with self.assertRaises(SystemExit):
+            _parse_runs(["a=/x", "a=/y"])
+
+
+class EvaluateE2ETest(unittest.TestCase):
+    def test_two_runs_ranks_good_first(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            good = write_run(root / "good", [make_dolma_record("/docs/a.pdf", CLEAN)])
+            bad = write_run(root / "bad", [make_dolma_record("/docs/a.pdf", GARBLED)])
+            db_path = root / "eval.sqlite"
+
+            rc = main(["evaluate", "--run", f"good={good}", "--run", f"bad={bad}", "--db", str(db_path)])
+            self.assertEqual(rc, 0)
+
+            con = sqlite3.connect(db_path)
+            # both runs registered
+            self.assertEqual({r[0] for r in con.execute("SELECT model FROM runs")}, {"good", "bad"})
+            # good's text needs fewer spell-corrections than bad's (lower is better)
+            means = dict(con.execute("SELECT model, AVG(correction_rate) FROM correction_rate GROUP BY model"))
+            self.assertLess(means["good"], means["bad"])
+            # peer agreement rows exist (2 models, shared doc/pages)
+            self.assertGreater(con.execute("SELECT COUNT(*) FROM peer_agreement").fetchone()[0], 0)
+            con.close()
+
+    def test_single_run_skips_peer_agreement(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            good = write_run(root / "good", [make_dolma_record("/docs/a.pdf", CLEAN)])
+            rc = main(["evaluate", "--run", f"good={good}", "--db", str(root / "eval.sqlite")])
+            self.assertEqual(rc, 0)
+            con = sqlite3.connect(root / "eval.sqlite")
+            self.assertEqual(con.execute("SELECT COUNT(*) FROM peer_agreement").fetchone()[0], 0)
+            con.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evaluation/test_db.py
+++ b/tests/evaluation/test_db.py
@@ -88,6 +88,21 @@ class LeaderboardTest(unittest.TestCase):
         self.assertIn("0.67", a_line)
         self.assertNotIn("0.75", a_line)
 
+    def test_leaderboard_mean_is_doc_weighted_not_page_weighted(self):
+        # d1 has 3 pages @0.9, d2 has 1 page @0.0. Doc-mean = (0.9+0.0)/2 = 0.450,
+        # NOT the page-weighted 0.675 = (0.9*3 + 0.0)/4 -- a big doc must not dominate.
+        with tempfile.TemporaryDirectory() as d:
+            db = EvalDB(Path(d) / "eval.db")
+            db.write_correction_rate([
+                ("a", "d1", 1, 0.9, 0.0), ("a", "d1", 2, 0.9, 0.0), ("a", "d1", 3, 0.9, 0.0),
+                ("a", "d2", 1, 0.0, 0.0),
+            ])
+            out = db.leaderboard()
+            db.close()
+        line = _line_for(out, "a")
+        self.assertIn("0.450", line)
+        self.assertNotIn("0.675", line)
+
     def test_single_model_win_rate_na(self):
         with tempfile.TemporaryDirectory() as d:
             db = EvalDB(Path(d) / "eval.db")

--- a/tests/evaluation/test_db.py
+++ b/tests/evaluation/test_db.py
@@ -1,0 +1,132 @@
+"""Tests for the SQLite eval store + leaderboard."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from paperscale.evaluation.db import EvalDB
+
+
+def _line_for(text: str, model: str) -> str:
+    for line in text.splitlines():
+        if line.split()[:1] == [model]:
+            return line
+    raise AssertionError(f"no row for model {model!r} in:\n{text}")
+
+
+class RoundTripTest(unittest.TestCase):
+    def test_persists_across_reopen(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "eval.db"
+            db = EvalDB(path)
+            db.register_run("a", "/runs/a")
+            db.write_correction_rate([("a", "doc1", 1, 0.1, 0.0), ("a", "doc1", 2, 0.3, 0.2)])
+            db.close()
+
+            db2 = EvalDB(path)
+            rows = db2.conn.execute(
+                "SELECT model, doc, page, correction_rate, uncorrectable_rate FROM correction_rate ORDER BY page"
+            ).fetchall()
+            db2.close()
+        self.assertEqual(rows, [("a", "doc1", 1, 0.1, 0.0), ("a", "doc1", 2, 0.3, 0.2)])
+
+
+class IdempotencyTest(unittest.TestCase):
+    def test_rewriting_replaces_not_duplicates(self):
+        with tempfile.TemporaryDirectory() as d:
+            db = EvalDB(Path(d) / "eval.db")
+            rows = [("a", "doc1", 1, 0.5, 0.1), ("a", "doc1", 2, 0.6, 0.2)]
+            db.write_correction_rate(rows)
+            db.write_correction_rate(rows)  # re-run
+            n = db.conn.execute("SELECT COUNT(*) FROM correction_rate").fetchone()[0]
+            db.close()
+        self.assertEqual(n, 2)
+
+    def test_rewriting_one_model_leaves_others(self):
+        with tempfile.TemporaryDirectory() as d:
+            db = EvalDB(Path(d) / "eval.db")
+            db.write_correction_rate([("a", "doc1", 1, 0.5, 0.0)])
+            db.write_correction_rate([("b", "doc1", 1, 0.8, 0.0)])
+            db.write_correction_rate([("a", "doc1", 1, 0.9, 0.0)])  # rewrite a only
+            rows = db.conn.execute(
+                "SELECT model, correction_rate FROM correction_rate ORDER BY model"
+            ).fetchall()
+            db.close()
+        self.assertEqual(rows, [("a", 0.9), ("b", 0.8)])
+
+
+class LeaderboardTest(unittest.TestCase):
+    def test_means_and_win_rate(self):
+        # correction_rate is LOWER-better.
+        # a: d1=.1 d2=.2 d3=.5  (mean 0.8/3 = 0.267); wins d1,d2 -> 2/3 = 0.67
+        # b: d1=.3 d2=.4 d3=.1  (mean 0.8/3 = 0.267); wins d3     -> 1/3 = 0.33
+        with tempfile.TemporaryDirectory() as d:
+            db = EvalDB(Path(d) / "eval.db")
+            db.write_correction_rate([
+                ("a", "d1", 1, 0.1, 0.0), ("a", "d2", 1, 0.2, 0.0), ("a", "d3", 1, 0.5, 0.0),
+                ("b", "d1", 1, 0.3, 0.0), ("b", "d2", 1, 0.4, 0.0), ("b", "d3", 1, 0.1, 0.0),
+            ])
+            out = db.leaderboard()
+            db.close()
+        self.assertIn("0.267", _line_for(out, "a"))  # hand-computed mean
+        self.assertIn("0.67", _line_for(out, "a"))    # winner win-rate (lower better)
+        self.assertIn("0.33", _line_for(out, "b"))
+
+    def test_win_rate_restricted_to_common_docs(self):
+        # a has an extra d4 that b lacks -> d4 must NOT count toward win-rate.
+        # Common docs = {d1,d2,d3}; a wins d1,d2 (lower) -> 2/3 = 0.67 (NOT 3/4 = 0.75).
+        with tempfile.TemporaryDirectory() as d:
+            db = EvalDB(Path(d) / "eval.db")
+            db.write_correction_rate([
+                ("a", "d1", 1, 0.1, 0.0), ("a", "d2", 1, 0.2, 0.0), ("a", "d3", 1, 0.5, 0.0),
+                ("a", "d4", 1, 0.01, 0.0),  # b lacks d4
+                ("b", "d1", 1, 0.3, 0.0), ("b", "d2", 1, 0.4, 0.0), ("b", "d3", 1, 0.1, 0.0),
+            ])
+            out = db.leaderboard()
+            db.close()
+        a_line = _line_for(out, "a")
+        self.assertIn("0.67", a_line)
+        self.assertNotIn("0.75", a_line)
+
+    def test_single_model_win_rate_na(self):
+        with tempfile.TemporaryDirectory() as d:
+            db = EvalDB(Path(d) / "eval.db")
+            db.write_correction_rate([("a", "d1", 1, 0.5, 0.0)])
+            out = db.leaderboard()
+            db.close()
+        self.assertIn("n/a", _line_for(out, "a"))
+
+
+class PplxTest(unittest.TestCase):
+    def test_pplx_table_created_and_shown(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "eval.db"
+            db = EvalDB(path)
+            db.write_correction_rate([("my-model", "d1", 1, 0.5, 0.0)])
+            # rows: (doc, page, n_tok_raw, sum_lp_raw, ppl_raw, n_tok_c, sum_lp_c, ppl_c)
+            db.write_pplx("my-model", [
+                ("d1", 1, 10, -5.0, 4.0, 10, -4.0, 2.0),
+                ("d1", 2, 10, -5.0, 6.0, 10, -4.0, 4.0),
+            ])
+            tables = [r[0] for r in db.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'pplx_%'"
+            ).fetchall()]
+            out = db.leaderboard()
+            db.close()
+        self.assertIn("pplx_my_model", tables)
+        self.assertIn("ppl_raw", out)     # column header present
+        self.assertIn("5.000", out)       # mean ppl_raw = (4+6)/2 = 5
+        self.assertIn("3.000", out)       # mean ppl_corrected = (2+4)/2 = 3
+
+    def test_pplx_rewrite_replaces(self):
+        with tempfile.TemporaryDirectory() as d:
+            db = EvalDB(Path(d) / "eval.db")
+            db.write_pplx("m", [("d1", 1, 1, -1.0, 2.0, 1, -1.0, 2.0)])
+            db.write_pplx("m", [("d1", 1, 1, -1.0, 9.0, 1, -1.0, 9.0)])
+            n = db.conn.execute("SELECT COUNT(*) FROM pplx_m").fetchone()[0]
+            db.close()
+        self.assertEqual(n, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -24,6 +24,15 @@ class GarbageTest(unittest.TestCase):
     def test_none_on_empty(self):
         self.assertIsNone(garbage_token_fraction("   "))
 
+    def test_vowelless_run_flagged_but_not_acronyms(self):
+        from paperscale.evaluation.metrics import _is_garbage
+
+        self.assertTrue(_is_garbage("brwn"))       # lowercase vowel-less OCR garble
+        self.assertTrue(_is_garbage("brwnjmps"))
+        self.assertFalse(_is_garbage("PDF"))       # all-caps acronym preserved
+        self.assertFalse(_is_garbage("XML"))
+        self.assertFalse(_is_garbage("cat"))       # has a vowel
+
 
 class AgreementTest(unittest.TestCase):
     def test_identical_perfect(self):

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -1,0 +1,51 @@
+"""Tests for pure per-page metrics."""
+
+import unittest
+
+from paperscale.evaluation.metrics import (
+    bow_f1,
+    garbage_token_fraction,
+    normalize_markdown,
+    one_minus_ned,
+)
+
+CLEAN = "The quick brown fox jumps over the lazy dog every morning."
+GARBLED = "Teh qckuz brwn fxo jmps ovr teh lzy dg3 xkcdqz mrnng thzzzz."
+REPEAT = "error error error error error error error error error error"
+
+
+class GarbageTest(unittest.TestCase):
+    def test_clean_low_garbled_high(self):
+        self.assertLess(garbage_token_fraction(CLEAN), garbage_token_fraction(GARBLED))
+
+    def test_repeat_chars_flagged(self):
+        self.assertGreater(garbage_token_fraction("thzzzz aaaaaa"), 0.5)
+
+    def test_none_on_empty(self):
+        self.assertIsNone(garbage_token_fraction("   "))
+
+
+class AgreementTest(unittest.TestCase):
+    def test_identical_perfect(self):
+        self.assertEqual(bow_f1(CLEAN, CLEAN), 1.0)
+        self.assertEqual(one_minus_ned(CLEAN, CLEAN), 1.0)
+
+    def test_symmetric(self):
+        self.assertAlmostEqual(bow_f1(CLEAN, GARBLED), bow_f1(GARBLED, CLEAN))
+        self.assertAlmostEqual(one_minus_ned(CLEAN, GARBLED), one_minus_ned(GARBLED, CLEAN))
+
+    def test_reorder_high_bow_low_ned(self):
+        a = "alpha beta gamma delta epsilon"
+        b = "epsilon delta gamma beta alpha"
+        self.assertEqual(bow_f1(a, b), 1.0)  # same bag of words
+        self.assertLess(one_minus_ned(a, b), 0.6)  # but very different sequence
+
+    def test_disjoint_zero_bow(self):
+        self.assertEqual(bow_f1("one two three", "four five six"), 0.0)
+
+    def test_normalize_strips_markdown(self):
+        self.assertEqual(normalize_markdown("# **Hello** [world](http://x)  `code`"), "Hello world code")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evaluation/test_pplx.py
+++ b/tests/evaluation/test_pplx.py
@@ -32,6 +32,18 @@ def _fake_handler(request: httpx.Request) -> httpx.Response:
     return httpx.Response(200, json={"choices": [{"prompt_logprobs": plps}]})
 
 
+def _overrun_handler(request: httpx.Request) -> httpx.Response:
+    """Like _fake_handler but each decoded_token is padded, so the decoded chars
+    overrun the prompt -- the scorer should warn rather than silently misalign."""
+    body = json.loads(request.content)
+    prompt = body["prompt"]
+    chunks = [prompt[i : i + 4] for i in range(0, len(prompt), 4)]
+    plps = [None] + [
+        {"7": {"logprob": _LOGPROB, "decoded_token": ch + "XXXXX", "rank": 0}} for ch in chunks[1:]
+    ]
+    return httpx.Response(200, json={"choices": [{"prompt_logprobs": plps}]})
+
+
 def _client() -> httpx.Client:
     return httpx.Client(transport=httpx.MockTransport(_fake_handler))
 
@@ -65,6 +77,12 @@ class ScoreRunPplxTest(unittest.TestCase):
         self.assertEqual(n_c1, 1)
         self.assertEqual(n_c2, 1)
         self.assertAlmostEqual(s_c1, _LOGPROB)
+
+    def test_warns_when_decoded_tokens_overrun_prompt(self):
+        pages = [PageText("m", "/d.pdf", 1, "hello"), PageText("m", "/d.pdf", 2, "world")]
+        client = httpx.Client(transport=httpx.MockTransport(_overrun_handler))
+        with client, self.assertWarns(UserWarning):
+            pplx.score_run_pplx(pages, pplx_url="http://x", pplx_model="q", client=client)
 
     def test_ppl_is_exp_neg_mean_logprob(self):
         pages = [PageText("m", "/d.pdf", 1, "hello"), PageText("m", "/d.pdf", 2, "world")]

--- a/tests/evaluation/test_pplx.py
+++ b/tests/evaluation/test_pplx.py
@@ -1,0 +1,115 @@
+"""Tests for the opt-in perplexity scorer (no live network -- httpx.MockTransport)."""
+
+import json
+import math
+import unittest
+
+import httpx
+
+from paperscale.evaluation import pplx
+from paperscale.evaluation.runs import PageText
+
+_LOGPROB = -0.5
+
+
+def _fake_handler(request: httpx.Request) -> httpx.Response:
+    """Fake vLLM /v1/completions.
+
+    Tokenizes the prompt into fixed 4-char chunks whose decoded_tokens
+    reconstruct the prompt. The FIRST entry is null (no logprob, no
+    decoded_token -- its span is inferred by the scorer). Every other entry is a
+    dict ``{token_id: {"logprob", "decoded_token", "rank": 0}}``.
+    """
+    body = json.loads(request.content)
+    prompt = body["prompt"]
+    chunks = [prompt[i : i + 4] for i in range(0, len(prompt), 4)]
+    plps = []
+    for idx, ch in enumerate(chunks):
+        if idx == 0:
+            plps.append(None)
+        else:
+            plps.append({"7": {"logprob": _LOGPROB, "decoded_token": ch, "rank": 0}})
+    return httpx.Response(200, json={"choices": [{"prompt_logprobs": plps}]})
+
+
+def _client() -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(_fake_handler))
+
+
+class ScoreRunPplxTest(unittest.TestCase):
+    def test_offset_mapping_excludes_null_token_and_runs_both_passes(self):
+        # raw joined = "hello\nworld" (len 11); 4-char tokens:
+        #   "hell"[0,4) null   "o\nwo"[4,8) -> page1 (4 < 6)   "rld"[8,11) -> page2
+        # boundaries: page1@0, page2@6. Null "hell" (page1) is excluded from sums.
+        pages = [
+            PageText("m", "/d.pdf", 1, "hello"),
+            PageText("m", "/d.pdf", 2, "world"),
+        ]
+        with _client() as c:
+            out = pplx.score_run_pplx(
+                pages, pplx_url="http://vllm", pplx_model="q", client=c
+            )
+        rows = out["/d.pdf"]
+        self.assertEqual(len(rows), 2)
+
+        (doc1, pg1, n_r1, s_r1, ppl_r1, n_c1, s_c1, ppl_c1) = rows[0]
+        (doc2, pg2, n_r2, s_r2, ppl_r2, n_c2, s_c2, ppl_c2) = rows[1]
+        self.assertEqual((doc1, pg1), ("/d.pdf", 1))
+        self.assertEqual((doc2, pg2), ("/d.pdf", 2))
+        # exactly one scored token per page; null token did NOT count toward page1
+        self.assertEqual(n_r1, 1)
+        self.assertEqual(n_r2, 1)
+        self.assertAlmostEqual(s_r1, _LOGPROB)
+        self.assertAlmostEqual(s_r2, _LOGPROB)
+        # both passes populated ("hello"/"world" are real words -> corrected == raw)
+        self.assertEqual(n_c1, 1)
+        self.assertEqual(n_c2, 1)
+        self.assertAlmostEqual(s_c1, _LOGPROB)
+
+    def test_ppl_is_exp_neg_mean_logprob(self):
+        pages = [PageText("m", "/d.pdf", 1, "hello"), PageText("m", "/d.pdf", 2, "world")]
+        with _client() as c:
+            rows = pplx.score_run_pplx(
+                pages, pplx_url="http://x", pplx_model="q", client=c
+            )["/d.pdf"]
+        for (_doc, _pg, n, s, ppl, *_rest) in rows:
+            self.assertAlmostEqual(ppl, math.exp(-s / n))
+
+    def test_chunking_stitches_per_page_results(self):
+        # Force one chunk per page and confirm results match the single-prompt path.
+        pages = [PageText("m", "/d.pdf", 1, "hello"), PageText("m", "/d.pdf", 2, "world")]
+        orig_cap, orig_cpt = pplx._MAX_TOKENS_PER_CHUNK, pplx._CHARS_PER_TOKEN
+        pplx._MAX_TOKENS_PER_CHUNK, pplx._CHARS_PER_TOKEN = 0, 1
+        try:
+            with _client() as c:
+                rows = pplx.score_run_pplx(
+                    pages, pplx_url="http://x", pplx_model="q", client=c
+                )["/d.pdf"]
+        finally:
+            pplx._MAX_TOKENS_PER_CHUNK, pplx._CHARS_PER_TOKEN = orig_cap, orig_cpt
+        self.assertEqual([(r[1], r[2]) for r in rows], [(1, 1), (2, 1)])
+
+
+class CorrectTextTest(unittest.TestCase):
+    def test_corrects_misspelling_preserves_numbers_and_punct(self):
+        sym = pplx.build_dictionary()
+        # "wrold" is an OCR-style garble absent from the 50k list (unlike common
+        # web misspellings such as "teh", which wordfreq actually contains).
+        out = pplx.correct_text("wrold cat 42, ok!", sym)
+        self.assertIn("world", out)
+        self.assertNotIn("wrold", out)
+        self.assertIn("cat", out)  # already correct -> untouched
+        self.assertIn("42", out)  # number preserved
+        self.assertIn(",", out)  # punctuation preserved
+        self.assertTrue(out.endswith("!"))
+
+
+class BuildDictionaryTest(unittest.TestCase):
+    def test_lazy_import_and_extra_words(self):
+        sym = pplx.build_dictionary(frozenset({"zzzq"}))
+        self.assertIn("the", sym.words)
+        self.assertIn("zzzq", sym.words)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evaluation/test_runs.py
+++ b/tests/evaluation/test_runs.py
@@ -1,0 +1,46 @@
+"""Tests for the Dolma-JSONL run loader."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from paperscale.evaluation.runs import DuplicateSourceFileError, load_run
+from tests.evaluation.fixtures import make_dolma_record, write_run
+
+
+class LoadRunTest(unittest.TestCase):
+    def test_slices_pages_by_span_and_joins_on_source_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            rec = make_dolma_record("/docs/a.pdf", ["alpha", "beta"])
+            ws = write_run(Path(d), [rec])
+            pages, metas = load_run("good", ws)
+        # spans include the inter-page "\n" separator, faithful to build_dolma_document
+        self.assertEqual([(p.page, p.text) for p in pages], [(1, "alpha\n"), (2, "beta")])
+        self.assertTrue(all(p.model == "good" and p.doc == "/docs/a.pdf" for p in pages))
+        self.assertEqual(metas[0].total_pages, 2)
+        self.assertEqual(metas[0].fallback_pages, 0)
+
+    def test_skips_zero_length_blank_pages(self):
+        with tempfile.TemporaryDirectory() as d:
+            rec = make_dolma_record("/docs/a.pdf", ["alpha", "", "gamma"])
+            ws = write_run(Path(d), [rec])
+            pages, _ = load_run("m", ws)
+        self.assertEqual([p.page for p in pages], [1, 3])  # blank page 2 dropped
+
+    def test_bare_jsonl_file_input(self):
+        with tempfile.TemporaryDirectory() as d:
+            rec = make_dolma_record("/docs/a.pdf", ["x"])
+            f = write_run(Path(d), [rec], as_workspace=False)
+            pages, _ = load_run("m", f)
+        self.assertEqual(len(pages), 1)
+
+    def test_duplicate_source_file_raises(self):
+        with tempfile.TemporaryDirectory() as d:
+            recs = [make_dolma_record("/docs/a.pdf", ["x"]), make_dolma_record("/docs/a.pdf", ["y"])]
+            ws = write_run(Path(d), recs)
+            with self.assertRaises(DuplicateSourceFileError):
+                load_run("m", ws)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evaluation/test_spell.py
+++ b/tests/evaluation/test_spell.py
@@ -1,0 +1,49 @@
+"""Tests for the shared symspell dictionary + correction-counting."""
+
+import unittest
+
+from paperscale.evaluation.spell import build_dictionary, correct_text, correction_counts
+
+
+class CorrectionCountsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.sym = build_dictionary()
+
+    def test_clean_text_needs_no_corrections(self):
+        n, corrected, uncorrectable = correction_counts("the quick brown fox", self.sym)
+        self.assertEqual((corrected, uncorrectable), (0, 0))
+        self.assertEqual(n, 4)
+
+    def test_typos_are_correctable(self):
+        # "quikc"/"brwn" are edit-distance<=2 from real words -> correctable.
+        n, corrected, uncorrectable = correction_counts("quikc brwn", self.sym)
+        self.assertEqual(corrected, 2)
+        self.assertEqual(uncorrectable, 0)
+
+    def test_unrecoverable_garbage_is_uncorrectable(self):
+        # random consonant soup has no near dictionary word.
+        _, corrected, uncorrectable = correction_counts("xkcdqz zzqwvbf", self.sym)
+        self.assertEqual(corrected, 0)
+        self.assertEqual(uncorrectable, 2)
+
+    def test_none_when_no_alpha_tokens(self):
+        self.assertIsNone(correction_counts("123 456 !!! ---", self.sym))
+
+    def test_extra_words_treated_as_known(self):
+        sym = build_dictionary(frozenset({"zzqxword"}))
+        n, corrected, uncorrectable = correction_counts("zzqxword", sym)
+        self.assertEqual((corrected, uncorrectable), (0, 0))
+
+
+class CorrectTextTest(unittest.TestCase):
+    def test_fixes_word_keeps_numbers_and_punctuation(self):
+        sym = build_dictionary()
+        out = correct_text("wrold cat 42, ok!", sym)
+        self.assertIn("world", out)   # wrold -> world
+        self.assertIn("42,", out)     # number + punctuation untouched
+        self.assertTrue(out.endswith("!"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evaluation/test_textlayer.py
+++ b/tests/evaluation/test_textlayer.py
@@ -1,0 +1,103 @@
+"""Tests for text-layer agreement. Deterministic without poppler/real PDFs:
+`get_anchor_text` and the on-disk existence check are monkeypatched.
+"""
+
+import shutil
+import unittest
+
+from paperscale.evaluation import textlayer
+from paperscale.evaluation.runs import DocMeta, PageText
+
+LAYER = "The quick brown fox jumps over the lazy dog every single morning today."
+
+
+def _page(text="hello world this is a page of ocr output", doc="/x/a.pdf", page=1, model="m"):
+    return PageText(model=model, doc=doc, page=page, text=text)
+
+
+def _meta(fallback=0, doc="/x/a.pdf", model="m"):
+    return DocMeta(model=model, doc=doc, total_pages=1, fallback_pages=fallback, source_file=doc)
+
+
+class TextLayerTest(unittest.TestCase):
+    def setUp(self):
+        self._orig_exists = textlayer._pdf_exists
+        self._orig_anchor = textlayer.get_anchor_text
+        textlayer._pdf_exists = lambda p: True
+        textlayer.get_anchor_text = lambda doc, page, engine, target_length=4000: LAYER
+
+    def tearDown(self):
+        textlayer._pdf_exists = self._orig_exists
+        textlayer.get_anchor_text = self._orig_anchor
+
+    def test_fallback_doc_skipped(self):
+        rows, rep = textlayer.compute_textlayer_agreement([_page()], [_meta(fallback=3)])
+        self.assertEqual(rows, [])
+        self.assertEqual(rep.docs_with_fallback, 1)
+
+    def test_missing_pdf_skipped(self):
+        textlayer._pdf_exists = lambda p: False
+        rows, rep = textlayer.compute_textlayer_agreement([_page()], [_meta()])
+        self.assertEqual(rows, [])
+        self.assertEqual(rep.docs_missing_pdf, 1)
+
+    def test_blank_layer_skipped(self):
+        textlayer.get_anchor_text = lambda doc, page, engine, target_length=4000: "12"
+        rows, rep = textlayer.compute_textlayer_agreement([_page()], [_meta()])
+        self.assertEqual(rows, [])
+        self.assertEqual(rep.pages_blank_layer, 1)
+
+    def test_agreement_computed(self):
+        rows, rep = textlayer.compute_textlayer_agreement([_page()], [_meta()])
+        self.assertEqual(len(rows), 1)
+        model, doc, page, f1, ned = rows[0]
+        self.assertEqual((model, doc, page), ("m", "/x/a.pdf", 1))
+        for v in (f1, ned):
+            self.assertGreaterEqual(v, 0.0)
+            self.assertLessEqual(v, 1.0)
+
+    def test_identical_text_perfect(self):
+        rows, _ = textlayer.compute_textlayer_agreement([_page(text=LAYER)], [_meta()])
+        _, _, _, f1, ned = rows[0]
+        self.assertEqual(f1, 1.0)
+        self.assertEqual(ned, 1.0)
+
+    def test_pdftotext_error_falls_back_to_pypdf(self):
+        calls = []
+
+        def fake(doc, page, engine, target_length=4000):
+            calls.append(engine)
+            if engine == "pdftotext":
+                raise FileNotFoundError("no poppler")
+            return LAYER
+
+        textlayer.get_anchor_text = fake
+        rows, _ = textlayer.compute_textlayer_agreement([_page()], [_meta()])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(calls, ["pdftotext", "pypdf"])
+
+    @unittest.skipUnless(shutil.which("pdftotext"), "pdftotext not installed")
+    def test_real_pdftotext_smoke(self):
+        import tempfile
+
+        # Build a one-page PDF with a real text layer; skip if we can't cheaply.
+        try:
+            from reportlab.pdfgen import canvas
+        except ImportError:
+            self.skipTest("reportlab not installed")
+
+        line = "The quick brown fox jumps over the lazy dog every morning."
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as fh:
+            path = fh.name
+        c = canvas.Canvas(path)
+        c.drawString(72, 720, line)
+        c.save()
+
+        textlayer.get_anchor_text = self._orig_anchor  # use the real extractor
+        rows, _ = textlayer.compute_textlayer_agreement([_page(text=line, doc=path)], [_meta(doc=path)])
+        self.assertEqual(len(rows), 1)
+        self.assertGreater(rows[0][3], 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,69 @@
+"""Tests for the progress-reporter abstraction and its wiring."""
+
+import io
+import unittest
+
+from paperscale.evaluation.runs import DocMeta, PageText
+from paperscale.evaluation.textlayer import compute_textlayer_agreement
+from paperscale.tui import NullReporter, RichReporter, make_reporter
+
+
+class _FakeTTY(io.StringIO):
+    def __init__(self, tty: bool):
+        super().__init__()
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+class FactoryTest(unittest.TestCase):
+    def test_null_when_tui_off(self):
+        self.assertIsInstance(make_reporter(False, title="x", stream=_FakeTTY(True)), NullReporter)
+
+    def test_null_when_not_a_tty(self):
+        self.assertIsInstance(make_reporter(True, title="x", stream=_FakeTTY(False)), NullReporter)
+
+    def test_rich_when_tui_and_tty(self):
+        self.assertIsInstance(make_reporter(True, title="x", stream=_FakeTTY(True)), RichReporter)
+
+
+class NullReporterTest(unittest.TestCase):
+    def test_drive_is_noop(self):
+        with NullReporter() as rep:
+            rep.set_stat("pages", 3)
+            ph = rep.phase("work", total=2)
+            ph.advance()
+            ph.advance()
+            ph.done()
+            rep.log("hello")  # should not raise
+
+
+class RichReporterSmokeTest(unittest.TestCase):
+    def test_renders_without_error(self):
+        from rich.console import Console
+
+        buf = io.StringIO()
+        console = Console(file=buf, force_terminal=True, width=80)
+        rep = RichReporter("paperscale evaluate", console=console)
+        with rep:
+            rep.set_stat("models", 2)
+            ph = rep.phase("scoring", total=2)
+            ph.advance()
+            ph.done()
+            rep.log("an event")
+        self.assertIn("paperscale evaluate", buf.getvalue())
+
+
+class TextlayerProgressTest(unittest.TestCase):
+    def test_progress_called_once_per_page(self):
+        pages = [PageText("m", "/a.pdf", 1, "x"), PageText("m", "/a.pdf", 2, "y")]
+        metas = [DocMeta("m", "/a.pdf", 2, 1, "/a.pdf")]  # fallback_pages>0 -> doc skipped, but progress still fires per page
+        calls = []
+        rows, _ = compute_textlayer_agreement(pages, metas, progress=lambda note: calls.append(note))
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(rows, [])  # fallback doc -> no rows
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `paperscale evaluate` — a **reference-free** way to rank OCR (VLM) models against each other from existing run outputs, with **no ground truth**. It consumes the Dolma JSONL a pipeline run already writes (`results/output_*.jsonl`), scores every page, stores per-page rows in SQLite, and prints a corpus-level leaderboard.

```
paperscale evaluate --run good=<workspace> --run bad=<workspace> [--pplx ...] [--tui]
```

## Metrics

All required except perplexity (opt-in):

| Metric | Signal |
|---|---|
| `correction_rate` / `uncorrectable_rate` | how much a spell checker must change the text (correctable) vs garbage it can't fix (uncorrectable), symspell top-50k |
| `garbage_token_fraction` | rmgarbage-style token heuristics |
| `peer_agreement` | bag-of-words F1 + 1−NED between models on shared pages |
| `textlayer_agreement` | agreement vs the PDF's embedded text layer (calibration subset) |
| `reject_rate` | doc-level quality-gate fallback rate |
| `pplx` (opt-in, `--pplx`) | raw + dictionary-corrected perplexity via an external vLLM |

Leaderboard shows per-metric doc-means plus a win-rate restricted to docs common to all models. No composite score.

## Highlights

- **`--tui`**: renderer-agnostic progress dashboard (immich-go-style, rich-backed), gated behind the optional `tui` extra; falls back cleanly to plain stderr on non-TTY. The reporter abstraction is general enough for the OCR pipeline to adopt later.
- **Perplexity validated live** against `Qwen/Qwen3.5-9B-Base` on a real vLLM (`prompt_logprobs` parsing, per-page char-offset mapping, raw-vs-corrected passes).
- Joins runs by `Source-File` (never the per-model record `id`); skips blank/fallback pages appropriately.

## Notes / accepted caveats

- The correction dictionary is `wordfreq` top-50k — stricter than a full-vocabulary check — so a rare-but-real word can register as a correction. Tunable in `spell.py`.
- On heavily-garbled OCR, `ppl_corrected` can exceed `ppl_raw` (symspell over-corrects garble into coherent-but-wrong words). Documented, not fixed — a future confidence-gating decision.
- `--pplx-model` has no default (required with `--pplx`); the shipped default checkpoint choice is left to the operator.

## Testing

- 149 passed / 1 skipped (the skip is a reportlab-gated poppler smoke test), ruff clean.
- Live `--pplx` smoke against real vLLM; live `--tui` dashboard rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
